### PR TITLE
Centralize timezone handling

### DIFF
--- a/apps/web/app/analysis/page.tsx
+++ b/apps/web/app/analysis/page.tsx
@@ -7,6 +7,7 @@ import { findTrades } from '@/lib/services/dataService';
 import { computeFifo, EnrichedTrade } from '@/lib/fifo';
 import { TradeCalendar } from '@/modules/TradeCalendar';
 import { RankingTable } from '@/modules/RankingTable';
+import { toNY } from '@/lib/timezone';
 
 export default function AnalysisPage() {
   const [isChartReady, setIsChartReady] = useState(false);
@@ -32,9 +33,9 @@ export default function AnalysisPage() {
     const fmt = (d: string) => {
       if (period === 'day') return d;
       if (period === 'week') {
-        const dt = new Date(d);
+        const dt = toNY(d);
         const y = dt.getFullYear();
-        const week = Math.ceil((((+dt) - +new Date(y, 0, 1)) / 86400000 + new Date(y, 0, 1).getDay() + 1) / 7);
+        const week = Math.ceil((((+dt) - +toNY(y, 0, 1)) / 86400000 + toNY(y, 0, 1).getDay() + 1) / 7);
         return `${y}-W${String(week).padStart(2, '0')}`;
       }
       // month

--- a/apps/web/app/components/AddTradeModal.tsx
+++ b/apps/web/app/components/AddTradeModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { addTrade, updateTrade } from '@/lib/services/dataService';
+import { nowNY, toNY } from '@/lib/timezone';
 
 interface Props {
   onClose: () => void;
@@ -11,7 +12,7 @@ function buildOptionSymbol(root: string, dateStr: string, cp: string, strike: nu
   if (!root || !dateStr || !cp || !strike) return '';
 
   // Format: AAPL230915C00165000
-  const date = new Date(dateStr);
+  const date = toNY(dateStr);
   const yy = date.getFullYear().toString().slice(-2);
   const mm = (date.getMonth() + 1).toString().padStart(2, '0');
   const dd = date.getDate().toString().padStart(2, '0');
@@ -35,10 +36,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
   const [optStrike, setOptStrike] = useState<number>(0);
 
   // Get current NY time for default
-  const now = new Date();
-  const nyTime = now.toLocaleString('en-US', { timeZone: 'America/New_York' });
-  const nyDate = new Date(nyTime);
-  const defaultDatetime = nyDate.toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM format
+  const defaultDatetime = nowNY().toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM format
 
   const [datetime, setDatetime] = useState(defaultDatetime);
 
@@ -65,8 +63,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
 
       // 处理日期 -> datetime-local 格式 (YYYY-MM-DDTHH:MM)
       try {
-        const d = new Date(trade.date);
-        const iso = d.toISOString(); // YYYY-MM-DDTHH:MM:SSZ
+        const iso = toNY(trade.date).toISOString(); // YYYY-MM-DDTHH:MM:SSZ
         setDatetime(iso.slice(0, 16));
       } catch (e) {
         console.error('无法解析日期:', trade.date, e);

--- a/apps/web/app/components/layout/Header.tsx
+++ b/apps/web/app/components/layout/Header.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { nowNY } from '@/lib/timezone';
 import { format } from 'date-fns';
 import { zhCN } from 'date-fns/locale/zh-CN';
 import { clearAndImportData, exportData, importClosePrices, getAllPrices } from '@/lib/services/dataService';
 
 export function Header() {
-  const [now, setNow] = useState(new Date());
+  const [now, setNow] = useState(nowNY());
   const [nyTime, setNyTime] = useState('');
   const [valenciaTime, setValenciaTime] = useState('');
   const [shanghaiTime, setShanghaiTime] = useState('');
@@ -14,7 +15,7 @@ export function Header() {
   useEffect(() => {
     // 更新所有时区的时间
     function updateAllTimes() {
-      const currentDate = new Date();
+      const currentDate = nowNY();
 
       // 获取各时区的时间
       setNyTime(currentDate.toLocaleTimeString('en-US', {
@@ -93,7 +94,7 @@ export function Header() {
       const data = {
         ...core,
         equityCurve: [],        // 暂无专门存储，留空占位
-        generated: new Date().toISOString()
+        generated: nowNY().toISOString()
       };
       const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
@@ -153,7 +154,7 @@ export function Header() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `close_prices_${new Date().toISOString().slice(0, 10)}.json`;
+      a.download = `close_prices_${nowNY().toISOString().slice(0, 10)}.json`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/apps/web/app/lib/fifo.ts
+++ b/apps/web/app/lib/fifo.ts
@@ -1,4 +1,5 @@
 import type { Trade } from './services/dataService';
+import { toNY } from './timezone';
 
 const EPSILON = 1e-6;
 
@@ -29,7 +30,7 @@ export function computeFifo(trades: Trade[]): EnrichedTrade[] {
   const symbolStateMap: Record<string, SymbolState> = {};
 
   // Sort trades by date to process them chronologically
-  const sortedTrades = [...trades].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  const sortedTrades = [...trades].sort((a, b) => toNY(a.date).getTime() - toNY(b.date).getTime());
 
   return sortedTrades.map((trade): EnrichedTrade => {
     const state = symbolStateMap[trade.symbol] || (symbolStateMap[trade.symbol] = {
@@ -99,7 +100,7 @@ export function computeFifo(trades: Trade[]): EnrichedTrade[] {
     const averageCost = totalQuantity > EPSILON ? costOfPositions / totalQuantity : 0;
     const breakEvenPrice = totalQuantity > EPSILON ? (costOfPositions - state.accumulatedRealizedPnl) / totalQuantity : 0;
 
-    const date = new Date(trade.date);
+    const date = toNY(trade.date);
     const weekday = ((date.getUTCDay() + 6) % 7) + 1; // Monday: 1, Sunday: 7
 
     return {

--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -12,6 +12,11 @@
  *   const date2 = toNY('2025-07-23');    // 任意 Date/字符串/时间戳
  *   const date3 = toNY(2025, 0, 1);      // 年月日，用法与 new Date(2025,0,1)
  */
+
+// Ensure server timezone defaults to New York
+if (typeof process !== 'undefined') {
+  process.env.TZ = process.env.TZ || 'America/New_York';
+}
 export function toNY(): Date;
 export function toNY(value: string | number | Date): Date;
 export function toNY(
@@ -66,3 +71,5 @@ export const formatNY = (
 // Attach helper to global for quick usage in dev tools
 // @ts-ignore
 (globalThis as any).toNY = toNY;
+(globalThis as any).nowNY = nowNY;
+(globalThis as any).formatNY = formatNY;

--- a/apps/web/app/modules/PnlByPeriodChart.tsx
+++ b/apps/web/app/modules/PnlByPeriodChart.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
+import { toNY } from '@/lib/timezone';
 import type { EnrichedTrade } from '@/lib/fifo';
 
 interface PnlByPeriodChartProps {
@@ -29,7 +30,7 @@ export function PnlByPeriodChart({ trades, period }: PnlByPeriodChartProps) {
     const pnlByPeriod: Record<string, number> = {};
 
     trades.forEach((trade) => {
-      const date = new Date(trade.date);
+      const date = toNY(trade.date);
       const key =
         period === 'monthly'
           ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`

--- a/apps/web/app/modules/PnlChart.tsx
+++ b/apps/web/app/modules/PnlChart.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { EnrichedTrade } from '@/lib/fifo';
 import Script from 'next/script';
+import { toNY } from '@/lib/timezone';
 
 interface PnlChartProps {
   trades: EnrichedTrade[];
@@ -30,14 +31,14 @@ export function PnlChart({ trades }: PnlChartProps) {
     trades.forEach(trade => {
       if (!trade.date) return; // Skip trades without a date
 
-      const date = new Date(trade.date);
+      const date = toNY(trade.date);
       let key = '';
 
       if (activeView === 'day') {
         key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
       } else if (activeView === 'week') {
         // Get the week number
-        const firstDayOfYear = new Date(date.getFullYear(), 0, 1);
+        const firstDayOfYear = toNY(date.getFullYear(), 0, 1);
         const pastDaysOfYear = (date.getTime() - firstDayOfYear.getTime()) / 86400000;
         const weekNumber = Math.ceil((pastDaysOfYear + firstDayOfYear.getDay() + 1) / 7);
         key = `${date.getFullYear()}-W${String(weekNumber).padStart(2, '0')}`;

--- a/apps/web/app/modules/TradeCalendar.tsx
+++ b/apps/web/app/modules/TradeCalendar.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { EnrichedTrade } from '@/lib/fifo';
 import { useMemo } from 'react';
+import { toNY } from '@/lib/timezone';
 
 interface TradeCalendarProps {
   trades: EnrichedTrade[];
@@ -59,9 +60,9 @@ export function TradeCalendar({ trades, title, id, isIntraday = false }: TradeCa
         {Object.entries(months).map(([month, arr]) => {
           // 计算该月第一天星期几
           const [yStr, mStr] = month.split('-');
-          const firstDate = new Date(Number(yStr), Number(mStr) - 1, 1);
+          const firstDate = toNY(Number(yStr), Number(mStr) - 1, 1);
           const firstWeekDay = firstDate.getDay();
-          const daysInMonth = new Date(Number(yStr), Number(mStr), 0).getDate();
+          const daysInMonth = toNY(Number(yStr), Number(mStr), 0).getDate();
           const dayMap: Record<number, number> = {};
           arr.forEach(d => { dayMap[d.day] = d.pnl ?? 0; });
           return (

--- a/apps/web/app/modules/TradesTable.tsx
+++ b/apps/web/app/modules/TradesTable.tsx
@@ -2,6 +2,7 @@
 
 import type { EnrichedTrade } from "@/lib/fifo";
 import { useEffect, useState } from "react";
+import { toNY } from '@/lib/timezone';
 
 function formatNumber(value: number | undefined, decimals = 2) {
   if (value === undefined || value === null) return '-';
@@ -37,7 +38,7 @@ export function TradesTable({ trades }: { trades: EnrichedTrade[] }) {
       </thead>
       <tbody>
         {trades.slice(0, 10).map((trade, idx) => {
-          const dateObj = new Date(trade.date);
+          const dateObj = toNY(trade.date);
           const weekday = weekdayMap[dateObj.getUTCDay()];
           const colorSide = (trade.action === 'buy' || trade.action === 'cover') ? 'green' : 'red';
           const qtyColor = colorSide;

--- a/apps/web/app/stock/page.tsx
+++ b/apps/web/app/stock/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { findTrades } from '@/lib/services/dataService';
 import { computeFifo, type EnrichedTrade } from '@/lib/fifo';
+import { toNY } from '@/lib/timezone';
 
 function formatNumber(value: number | undefined, decimals = 2) {
   if (value === undefined || value === null) return '-';
@@ -114,7 +115,7 @@ export default function StockPage() {
         <tbody>
           {trades.length > 0 ? (
             trades.map((trade, idx) => {
-              const dateObj = new Date(trade.date);
+              const dateObj = toNY(trade.date);
               const weekday = weekdayMap[dateObj.getUTCDay()];
               const plCls = (trade.realizedPnl || 0) > 0 ? 'green' : (trade.realizedPnl || 0) < 0 ? 'red' : 'white';
               const sideCls = (trade.action === 'buy' || trade.action === 'cover') ? 'green' : 'red';

--- a/apps/web/app/trades/page.tsx
+++ b/apps/web/app/trades/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { findTrades, deleteTrade } from '@/lib/services/dataService';
 import { computeFifo, type EnrichedTrade } from '@/lib/fifo';
 import AddTradeModal from '@/components/AddTradeModal';
+import { toNY } from '@/lib/timezone';
 
 export default function TradesPage() {
   const [trades, setTrades] = useState<EnrichedTrade[]>([]);
@@ -72,7 +73,7 @@ export default function TradesPage() {
         </thead>
         <tbody>
           {trades.map((trade, idx) => {
-            const dateObj = new Date(trade.date);
+            const dateObj = toNY(trade.date);
             const weekday = weekdayMap[dateObj.getUTCDay()];
             const sideCls = getSideClass(trade.action);
             const amt = trade.price * trade.quantity;

--- a/apps/web/components/AddTradeModal.tsx
+++ b/apps/web/components/AddTradeModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { addTrade, updateTrade } from '@/lib/services/dataService';
 import type { EnrichedTrade } from '@/lib/fifo';
+import { nowNY, toNY } from '@/lib/timezone';
 
 type Side = 'BUY' | 'SELL' | 'SHORT' | 'COVER';
 
@@ -17,7 +18,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
   const [side, setSide] = useState<Side>('BUY');
   const [qty, setQty] = useState(0);
   const [price, setPrice] = useState(0);
-  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
+  const [date, setDate] = useState(nowNY().toISOString().slice(0, 10));
 
   useEffect(() => {
     if (trade) {
@@ -30,14 +31,13 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
 
       // 确保日期格式正确
       try {
-        const tradeDate = new Date(trade.date);
-        const formattedDate = tradeDate.toISOString().slice(0, 10);
+        const formattedDate = toNY(trade.date).toISOString().slice(0, 10);
         setDate(formattedDate);
         console.log('设置日期:', formattedDate, '原始日期:', trade.date);
       } catch (e) {
         console.error('日期格式错误:', trade.date, e);
         // 回退到当前日期
-        setDate(new Date().toISOString().slice(0, 10));
+        setDate(nowNY().toISOString().slice(0, 10));
       }
     }
   }, [trade]);

--- a/apps/web/components/layout/Header.tsx
+++ b/apps/web/components/layout/Header.tsx
@@ -2,19 +2,20 @@
 
 import { useEffect, useState } from 'react';
 import { format, toZonedTime } from 'date-fns-tz';
+import { nowNY } from '@/lib/timezone';
 import { clearAndImportData, exportData } from '@/lib/services/dataService';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 
 // Match the original clocks div in the HTML
 export function Clocks() {
-  const [time, setTime] = useState(() => new Date()); // Use a function to prevent immediate execution on server import
+  const [time, setTime] = useState(() => nowNY()); // Use a function to prevent immediate execution on server import
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
     setIsClient(true);
     const timer = setInterval(() => {
-      setTime(new Date());
+      setTime(nowNY());
     }, 1000);
     return () => clearInterval(timer);
   }, []);
@@ -43,7 +44,7 @@ export function Clocks() {
 }
 
 function getNyDate(): string {
-  const now = new Date();
+  const now = nowNY();
   const nyDate = toZonedTime(now, 'America/New_York');
   return format(nyDate, 'yyyy-MM-dd');
 }
@@ -93,7 +94,7 @@ export function Header() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `trades-export-${new Date().toISOString().split('T')[0]}.json`;
+      a.download = `trades-export-${nowNY().toISOString().split('T')[0]}.json`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/apps/web/public/js/analysis.js
+++ b/apps/web/public/js/analysis.js
@@ -1,5 +1,6 @@
 /* Trading777 交易分析 – v7.7.3 */
 (function(){
+  const { nowNY, toNY } = window;
   /* ---------- utilities ---------- */
   function numberColor(v){
     if(v>0) return 'green';
@@ -10,7 +11,7 @@
 
   /* ---------- clock ---------- */
   function renderClocks(){
-    const fmt = tz => new Date().toLocaleTimeString('en-GB',{timeZone:tz,hour12:false});
+    const fmt = tz => nowNY().toLocaleTimeString('en-GB',{timeZone:tz,hour12:false});
     document.getElementById('clocks').innerHTML =
       `纽约：${fmt('America/New_York')} | 瓦伦西亚：${fmt('Europe/Madrid')} | 上海：${fmt('Asia/Shanghai')}`;
   };  // ← 加上分号
@@ -51,12 +52,12 @@
   const calendarWrap = document.getElementById('calendar-wrap');
   let curYearMonth = lastDate
     ? lastDate.slice(0,7)
-    : (new Date()).toISOString().slice(0,7);
+    : nowNY().toISOString().slice(0,7);
 
   function renderCalendar(ym){
     const [y,m] = ym.split('-').map(n=>parseInt(n,10));
-    const first = new Date(y, m-1, 1);
-    const last = new Date(y, m, 0);
+    const first = toNY(y, m-1, 1);
+    const last = toNY(y, m, 0);
     const startDow = (first.getDay()+6)%7; // Monday=0
     const weeks = Math.ceil((startDow + last.getDate())/7);
 
@@ -92,13 +93,13 @@
 
   document.getElementById('prev-month').onclick = ()=>{
     const [y,m] = curYearMonth.split('-').map(Number);
-    const date = new Date(y, m-2, 1);
+    const date = toNY(y, m-2, 1);
     curYearMonth = `${date.getFullYear()}-${String(date.getMonth()+1).padStart(2,'0')}`;
     renderCalendar(curYearMonth);
   };
   document.getElementById('next-month').onclick = ()=>{
     const [y,m] = curYearMonth.split('-').map(Number);
-    const date = new Date(y, m, 1);
+    const date = toNY(y, m, 1);
     curYearMonth = `${date.getFullYear()}-${String(date.getMonth()+1).padStart(2,'0')}`;
     renderCalendar(curYearMonth);
   };
@@ -155,7 +156,7 @@
 
 /* ---- v7.8.1 新增: Alpha Vantage 收盘价 + 当日浮动盈亏 ---- */
 ;(function(){
-  const today = new Date().toISOString().slice(0,10);
+  const today = nowNY().toISOString().slice(0,10);
 
   // Fetch Alpha Vantage key from KEY.txt (格式: Alpha key：XXXXX)
   function fetchAlphaKey(){

--- a/apps/web/public/js/analysisPage.js
+++ b/apps/web/public/js/analysisPage.js
@@ -1,4 +1,5 @@
 (function(){
+  const { toNY } = window;
   // 工具
   function numberColor(v){ return v>0?'green':(v<0?'red':'white'); }
   function formatDate(d){ return d.toISOString().slice(0,10); }
@@ -8,7 +9,7 @@
   if(!Array.isArray(trades) || trades.length===0) return;
 
   // 2. 按日期排序
-  trades.sort((a,b)=> new Date(a.date)-new Date(b.date));
+  trades.sort((a,b)=> toNY(a.date)-toNY(b.date));
   const allSymbols = [...new Set(trades.map(t=>t.symbol))];
   const allDates = trades.map(t=>t.date).sort();
   const minDate = allDates[0], maxDate = allDates[allDates.length-1];
@@ -107,13 +108,13 @@
       let grid=document.createElement('div');
       grid.className='calendar-grid';
       let [y,m]=month.split('-').map(Number);
-      let firstDate=new Date(y, m-1, 1), firstWeekDay=firstDate.getDay();
+      let firstDate=toNY(y, m-1, 1), firstWeekDay=firstDate.getDay();
       for(let i=0;i<firstWeekDay;i++){
         let cell=document.createElement('div');
         cell.className='calendar-cell zero';
         grid.appendChild(cell);
       }
-      let days=new Date(y, m, 0).getDate();
+      let days=toNY(y, m, 0).getDate();
       for(let d=1; d<=days; d++){
         let dateKey = month + '-' + String(d).padStart(2,'0');
         let pnl = dayMap[dateKey]||0;

--- a/apps/web/public/js/dailyClose.js
+++ b/apps/web/public/js/dailyClose.js
@@ -16,7 +16,8 @@ function getNYDateParts() {
     second: '2-digit',
     hour12: false,
   });
-  const partsArray = formatter.formatToParts(new Date());
+  const { nowNY } = window;
+  const partsArray = formatter.formatToParts(nowNY());
   const parts = {};
   for (const part of partsArray) {
     if (part.type !== 'literal') {

--- a/apps/web/public/js/dashboard.js
+++ b/apps/web/public/js/dashboard.js
@@ -2,14 +2,13 @@
 /* ---------- Prev Close attachment (v7.27) ---------- */
 
 /* ---------- Global Timezone helpers (v7.79) ---------- */
-const NY_TZ = 'America/New_York';
-// luxon already loaded globally
-const nyNow   = ()=> luxon.DateTime.now().setZone(NY_TZ);
-const todayNY = ()=> nyNow().toISODate();
+const { nowNY, toNY, formatNY } = window;
+const nyNow   = () => nowNY();
+const todayNY = () => nowNY().toISOString().slice(0,10);
 async function attachPrevCloses(){
   const idb = await import('./lib/idb.js');
-  const now = new Date();
-  let d = new Date(now);
+  const now = nowNY();
+  let d = toNY(now);
   // 找到上一个交易日（跳过周末）
   do{
     d.setDate(d.getDate()-1);
@@ -38,8 +37,8 @@ async function attachPrevCloses(){
 
 async function getPrevTradingDayClose(symbol){
   const idb = await import('./lib/idb.js');
-  const now = new Date();
-  let d = new Date(now);
+  const now = nowNY();
+  let d = toNY(now);
   d.setDate(d.getDate()-1);
   while(d.getDay()===0 || d.getDay()===6){ d.setDate(d.getDate()-1); }
   const dateStr = d.toISOString().slice(0,10);
@@ -108,7 +107,7 @@ function recalcPositions(){
   const symbolLots = {};   // {SYM: [{qty, price}] }
   const dayStr = todayNY();
 
-  trades.sort((a,b)=> new Date(a.date) - new Date(b.date));   // 确保按时间先后
+  trades.sort((a,b)=> toNY(a.date) - toNY(b.date));   // 确保按时间先后
 
   trades.forEach(t=>{
     const lots = symbolLots[t.symbol] || (symbolLots[t.symbol] = []);
@@ -240,7 +239,7 @@ const floating = positions.reduce((sum,p)=>{
 
 
   const latestTradeDate = trades.reduce((d,t)=> t.date>d ? t.date : d, '');
-  const todayStr = latestTradeDate || new Date().toLocaleDateString('en-CA', { timeZone:'America/New_York' });
+  const todayStr = latestTradeDate || nowNY().toISOString().slice(0,10);
   const todayTrades = trades.filter(t=> t.date === todayStr);
 // --- v7.53 修复：精确计算当日浮动盈亏（历史仓 + 今日仓） ---
 // 构建今日净买卖映射
@@ -286,15 +285,15 @@ const lossesTotal = trades.filter(t=> (t.pl||0) < 0).length;
 const winRate = (winsTotal + lossesTotal) ? winsTotal / (winsTotal + lossesTotal) * 100 : null;
 
 
-const now = new Date();
-const monday = new Date(now);
+const now = nowNY();
+const monday = toNY(now);
 monday.setDate(now.getDate() - ((now.getDay() + 6) % 7));
 monday.setHours(0,0,0,0);
 
-const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+const firstOfMonth = toNY(now.getFullYear(), now.getMonth(), 1);
 firstOfMonth.setHours(0,0,0,0);
 
-const firstOfYear = new Date(now.getFullYear(), 0, 1);
+const firstOfYear = toNY(now.getFullYear(), 0, 1);
 firstOfYear.setHours(0,0,0,0);
 
 // --- v7.75 重新计算 WTD/MTD/YTD（含每日浮动 + 已实现） ---
@@ -302,7 +301,7 @@ function sumPeriod(startDate){
   // startDate: JS Date at 00:00 local, inclusive
   const toISO = d => d.toISOString().slice(0,10);
   const startISO = toISO(startDate);
-  const todayISO = toISO(new Date());
+  const todayISO = toISO(nowNY());
 
   // ---- 1. Build daily realized P/L map ----
   const realizedDaily = {};
@@ -383,7 +382,7 @@ const ytdReal = sumPeriod(firstOfYear);
 
 
 function updateClocks(){
-  const fmt = tz => new Date().toLocaleTimeString('en-GB',{timeZone:tz,hour12:false});
+  const fmt = tz => nowNY().toLocaleTimeString('en-GB',{timeZone:tz,hour12:false});
   document.getElementById('clocks').innerHTML =
       `纽约：${fmt('America/New_York')} | 瓦伦西亚：${fmt('Europe/Madrid')} | 上海：${fmt('Asia/Shanghai')}`;
 }
@@ -454,7 +453,7 @@ function renderTrades(){
   if(!tbl) return;
   const head=['日期','星期','图标','代码','中文','方向','单价','数量','订单金额','详情'];
   tbl.innerHTML='<tr>'+head.map(h=>`<th class="${h==='中文'?'cn':''}">${h}</th>`).join('')+'</tr>';
-  trades.slice().sort((a,b)=> new Date(b.date)-new Date(a.date)).forEach(t=>{
+  trades.slice().sort((a,b)=> toNY(b.date)-toNY(a.date)).forEach(t=>{
     const amt=(t.qty*t.price).toFixed(2);
     const sideCls = t.side==='BUY' ? 'green' : t.side==='SELL' ? 'red' : t.side==='SHORT' ? 'purple' : 'blue';
     const wkAbbr = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][ getWeekIdx(t.date) ];
@@ -480,7 +479,7 @@ function addTrade(){
 
 /* Export */
 function exportData(){
-  const data={positions,trades,equityCurve:loadCurve(),generated:new Date().toISOString()};
+  const data={positions,trades,equityCurve:loadCurve(),generated:nowNY().toISOString()};
   const blob=new Blob([JSON.stringify(data,null,2)],{type:'application/json'});
   const url=URL.createObjectURL(blob);
   const a=document.createElement('a');
@@ -557,13 +556,7 @@ function openTradeForm(editIndex){
 
 // Set default trade datetime to now in New York timezone (America/New_York)
 if(editIndex==null){
-    const now = new Date();
-    // convert to New York timezone by using toLocaleString
-    const nyString = now.toLocaleString('en-US', {timeZone: 'America/New_York'});
-    const nyDate   = new Date(nyString);
-    const pad = (n)=>n.toString().padStart(2,'0');
-    const val = `${nyDate.getFullYear()}-${pad(nyDate.getMonth()+1)}-${pad(nyDate.getDate())}T${pad(nyDate.getHours())}:${pad(nyDate.getMinutes())}`;
-    document.getElementById('t-date').value = val;
+    document.getElementById('t-date').value = nowNY().toISOString().slice(0,16);
 }
   if(editIndex!=null){
      const t=trades[editIndex];
@@ -573,7 +566,7 @@ if(editIndex==null){
      document.getElementById('t-qty').value=t.qty;
      document.getElementById('t-price').value=t.price;
   }else{
-     document.getElementById('t-date').value=new Date().toISOString().slice(0,16);
+     document.getElementById('t-date').value=nowNY().toISOString().slice(0,16);
   }
   function close(){modal.remove();}
   
@@ -792,7 +785,7 @@ function refreshAll(){
 /* ---- NY Date Display ---- */
 function renderNYDate(){
   const opts = {timeZone:'America/New_York',year:'numeric',month:'2-digit',day:'2-digit',weekday:'short'};
-  document.getElementById('nyDate').textContent = new Intl.DateTimeFormat('zh-CN',opts).format(new Date());
+  document.getElementById('nyDate').textContent = new Intl.DateTimeFormat('zh-CN',opts).format(nowNY());
 }
 renderNYDate();
 setInterval(renderNYDate,60*1000);

--- a/apps/web/public/js/equityCurve.js
+++ b/apps/web/public/js/equityCurve.js
@@ -1,5 +1,6 @@
 
 (function(){
+  const { nowNY, toNY } = window;
   const STORAGE_KEY = 'equity_curve';
 
   function loadCurve(){
@@ -49,7 +50,7 @@
 /* ---- v7.8.1 新增: Alpha Vantage 收盘价 & 当日浮动盈亏自动更新 ---- */
 (function(){
   // 若曲线里已存在今天数据且执行过，则跳过
-  const today = new Date().toISOString().slice(0,10);
+  const today = nowNY().toISOString().slice(0,10);
   const curve = loadCurve();
   if(curve.some(p=> p.date===today && p.auto)) return;
 
@@ -60,7 +61,7 @@
   /* 1. 计算持仓 */
   function calcPositions(){
     const pos={};
-    trades.sort((a,b)=> new Date(a.date)-new Date(b.date));
+    trades.sort((a,b)=> toNY(a.date)-toNY(b.date));
     trades.forEach(t=>{
       const s=t.symbol, q=Number(t.qty), price=Number(t.price);
       if(t.side==='BUY' || t.side==='COVER'){

--- a/apps/web/public/js/fifo.js
+++ b/apps/web/public/js/fifo.js
@@ -7,12 +7,14 @@ function getWeekIdx(dateStr){
 
 /* FIFO cost calculation & metrics – ported from Apps Script (迭代3.3.2) */
 (function(g){
+  const { toNY } = window;
   function computeFIFO(allTrades){
     const EPS = 1e-6;
     const symMap = {};   // per‑symbol state
     // sort in-place by date asc (YYYY-MM-DD) then original order
+    const { toNY } = window;
     allTrades.sort((a,b)=>{
-      const d1 = new Date(a.date), d2 = new Date(b.date);
+      const d1 = toNY(a.date), d2 = toNY(b.date);
       return d1 - d2;
     });
 
@@ -93,7 +95,7 @@ function getWeekIdx(dateStr){
       }
 
       // enrich trade object
-      t.weekday = (function(d){ const w=d.getDay(); return ((w+6)%7)+1; })(new Date(t.date));
+      t.weekday = (function(d){ const w=d.getDay(); return ((w+6)%7)+1; })(toNY(t.date));
       t.count   = st.count;
       t.amount  = t.qty * t.price;
       t.be      = jVal;

--- a/apps/web/public/js/lib/idb.js
+++ b/apps/web/public/js/lib/idb.js
@@ -4,6 +4,7 @@
 const DB_NAME = 'TradingApp';
 const DB_VERSION = 1;
 const STORE_PRICES = 'prices';
+const { nowNY } = window;
 
 function _open() {
   return new Promise((resolve, reject) => {
@@ -75,7 +76,7 @@ export async function exportPrices() {
       const blob = new Blob([JSON.stringify(req.result, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
-      const today = new Date().toISOString().slice(0, 10);
+      const today = nowNY().toISOString().slice(0, 10);
       a.download = `prices_${today}.json`;
       a.href = url;
       a.click();

--- a/apps/web/public/js/services/priceService.js
+++ b/apps/web/public/js/services/priceService.js
@@ -4,6 +4,7 @@
  * No Node.js fs/path required – works on Vercel static hosting.
  */
 import { putPrice } from '../lib/idb.js';
+const { nowNY } = window;
 
 /** milliseconds to cache realtime quotes in localStorage */
 const RT_CACHE_MS = 60_000;
@@ -97,7 +98,7 @@ export async function fetchRealtimePrice(symbol){
  * Called by closeRecorder.js after market close.
  */
 export async function saveDailyClose(symbol, price){
-  const todayStr = new Date().toISOString().slice(0,10);
+  const todayStr = nowNY().toISOString().slice(0,10);
   await putPrice(symbol, todayStr, price, 'finnhub');
 }
 

--- a/apps/web/public/js/trades.js
+++ b/apps/web/public/js/trades.js
@@ -15,7 +15,8 @@ function getSideClass(side) {
 }
 function render(){
   let trades = JSON.parse(localStorage.getItem('trades')||'[]');
-  trades.sort((a,b)=> new Date(b.date)-new Date(a.date));
+  const { toNY } = window;
+  trades.sort((a,b)=> toNY(b.date)-toNY(a.date));
   trades = window.FIFO ? window.FIFO.computeFIFO(trades) : trades;
 
     const head=['#','logo','代码','中文','日期','星期','统计','方向','单价','数量','订单金额','盈亏平衡点','盈亏','详情','目前持仓','持仓成本','编辑','删除'];


### PR DESCRIPTION
## Summary
- rely on global helpers to consistently use New York time
- convert AddTradeModal and dashboard scripts to use nowNY/toNY
- expose timezone helpers globally and set TZ at runtime
- adjust charts and tables to use timezone helpers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a7bca190832e90536c18d5921a84