### PR TITLE
Improve metric display

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -6,6 +6,8 @@
   --c-green: #00e676;      /* positive number */
   --c-green-alt: #05c788;  /* secondary positive */
   --c-red: #ff5252;        /* negative number */
+  --c-blue: #0090ff;       /* informational blue */
+  --c-purple: #bb86fc;     /* short/cover highlight */
   --c-gray: #94a3b8;       /* secondary text */
 
   /* Layout */
@@ -87,8 +89,8 @@ body {
 
 /* Dashboard stats grid */
 .stats-grid {
-  display: grid;
-  grid-template-columns: repeat(8, 180px);
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   justify-content: center;
   margin: 20px auto;
@@ -110,6 +112,7 @@ body {
   background: #003030;
   border: 1px solid #00e67666;
   border-radius: 6px;
+  width: 180px;
   min-height: 100px;
   display: flex;
   flex-direction: column;
@@ -127,6 +130,8 @@ body {
 .value {
   font-size: 1rem;
   font-weight: 700;
+  white-space: pre-line;
+  text-align: center;
 }
 
 /* Box helper classes from legacy */
@@ -143,6 +148,8 @@ body {
 /* Color utility classes (legacy) */
 .green { color: var(--c-green); }
 .red   { color: var(--c-red); }
+.blue  { color: var(--c-blue); }
+.purple{ color: var(--c-purple); }
 .white { color: #ffffff; }
 
 .table {

--- a/apps/web/app/modules/DashboardMetrics.tsx
+++ b/apps/web/app/modules/DashboardMetrics.tsx
@@ -5,7 +5,7 @@ import type { Position } from '@/lib/services/dataService';
 import { useStore } from '@/lib/store';
 import { formatCurrency } from '@/lib/metrics';
 import type { Metrics } from '@/lib/metrics';
-import { useMemo } from 'react';
+import { useMemo, type ReactNode } from 'react';
 
 /**
  * DashboardMetrics 组件的属性接口
@@ -26,7 +26,7 @@ function MetricCard({
   colorClass
 }: {
   title: string;
-  value: string;
+  value: ReactNode;
   colorClass?: string;
 }) {
   return (
@@ -78,28 +78,50 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
   const formattedMetrics = useMemo(() => {
     return order.map(key => {
       const value = metrics[key];
-      let formattedValue: string;
+      let formattedValue: ReactNode;
       let colorClass = '';
 
       // 根据不同指标类型格式化值
       if (key === 'M5') {
         const m5 = value as Metrics['M5'];
-        formattedValue = `交易: ${formatCurrency(m5.trade)} | FIFO: ${formatCurrency(m5.fifo)}`;
+        const tradeCls = m5.trade > 0 ? 'green' : m5.trade < 0 ? 'red' : '';
+        const fifoCls = m5.fifo > 0 ? 'green' : m5.fifo < 0 ? 'red' : '';
+        formattedValue = (
+          <>
+            交易: <span className={tradeCls}>{formatCurrency(m5.trade)}</span>
+            <br />
+            FIFO: <span className={fifoCls}>{formatCurrency(m5.fifo)}</span>
+          </>
+        );
       }
       else if (key === 'M7' || key === 'M8') {
         const counts = value as Metrics['M7'] | Metrics['M8'];
-        formattedValue = `B/${counts.B} S/${counts.S} P/${counts.P} C/${counts.C} 【${counts.total}】`;
+        formattedValue = (
+          <>
+            <span className="green">B/{counts.B}</span>{' '}
+            <span className="red">S/{counts.S}</span>{' '}
+            <span className="purple">P/{counts.P}</span>{' '}
+            <span className="blue">C/{counts.C}</span>
+            <br />【{counts.total}】
+          </>
+        );
       }
       else if (key === 'M10') {
         const m10 = value as Metrics['M10'];
-        formattedValue = `W/${m10.W} L/${m10.L} ${m10.rate.toFixed(1)}%`;
+        formattedValue = (
+          <>
+            <span className="green">W/{m10.W}</span>{' '}
+            <span className="red">L/{m10.L}</span>{' '}
+            <span className="blue">{m10.rate.toFixed(1)}%</span>
+          </>
+        );
       }
       else {
         const numValue = value as number;
         formattedValue = formatCurrency(numValue);
 
         // 设置颜色
-        if (["M3", "M4", "M6", "M9", "M11", "M12", "M13"].includes(key)) {
+        if (["M1", "M2", "M3", "M4", "M6", "M9", "M11", "M12", "M13"].includes(key)) {
           colorClass = numValue > 0 ? 'green' : numValue < 0 ? 'red' : '';
         }
       }

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -15,6 +15,8 @@ export default {
         green: 'var(--c-green)',
         'green-alt': 'var(--c-green-alt)',
         red: 'var(--c-red)',
+        blue: 'var(--c-blue)',
+        purple: 'var(--c-purple)',
         gray: 'var(--c-gray)',
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- center metrics grid layout
- display multiline values correctly and color counts
- apply green/red coloring for M1 and M2
- add blue/purple highlight classes and color other metrics

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6885e75a1228832ea0304f7f0f8826d0