### PR TITLE
Add server-side quote proxy

### DIFF
--- a/apps/web/app/api/quote/route.ts
+++ b/apps/web/app/api/quote/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const symbol = request.nextUrl.searchParams.get('symbol');
+  if (!symbol) {
+    return new Response(JSON.stringify({ error: 'symbol is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+    });
+  }
+
+  const token = process.env.FINNHUB_API_KEY;
+  if (!token) {
+    return new Response(JSON.stringify({ error: 'FINNHUB_API_KEY not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+    });
+  }
+
+  const url = `https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(symbol)}&token=${token}`;
+  const resp = await fetch(url);
+  const data = await resp.json();
+
+  return new Response(JSON.stringify(data), {
+    status: resp.status,
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+  });
+}

--- a/apps/web/app/lib/services/priceService.ts
+++ b/apps/web/app/lib/services/priceService.ts
@@ -123,13 +123,8 @@ async function fetchFinnhubDailyClose(symbol: string, date: string): Promise<num
  * @returns 实时价格，如果未找到则返回 null
  */
 async function fetchFinnhubRealtimeQuote(symbol: string): Promise<number | null> {
-  const token = await getFinnhubToken();
-  if (!token) {
-    console.warn('未设置 Finnhub 令牌');
-    return null;
-  }
-
-  const url = `${FINNHUB_BASE_URL}/quote?symbol=${encodeURIComponent(symbol)}&token=${token}`;
+  // 请求改为调用内部 API 路由，避免在浏览器暴露密钥
+  const url = `/api/quote?symbol=${encodeURIComponent(symbol)}`;
 
   try {
     // 通过 apiQueue 限制请求速率

--- a/apps/web/public/js/dashboard.js
+++ b/apps/web/public/js/dashboard.js
@@ -708,7 +708,7 @@ function updatePrices(){
 
        // 为当前所有持仓并行请求价格，全部返回后再统一刷新界面
        const reqs = positions.map(p=>{
-         return fetch(`https://finnhub.io/api/v1/quote?symbol=${p.symbol}&token=${apiKey}`)
+         return fetch(`/api/quote?symbol=${p.symbol}`)
                 .then(r=>r.json())
                 .then(q=>{
                    if(q && q.c){ p.last = q.c; if(p.prevClose == null) p.prevClose = q.pc; p.priceOk = true; } else { p.priceOk = false; }

--- a/apps/web/public/js/services/priceService.js
+++ b/apps/web/public/js/services/priceService.js
@@ -72,14 +72,8 @@ export async function fetchRealtimePrice(symbol){
     }
   }catch{}
 
-  const { finnhub: rawToken } = await loadKeys();
-  const finnhub = resolveFinnhubToken(rawToken);
-  if(!finnhub){
-    console.warn('[priceService] Finnhub API key missing');
-    return null;
-  }
   try{
-    const url = `https://finnhub.io/api/v1/quote?symbol=${symbol}&token=${finnhub}`;
+    const url = `/api/quote?symbol=${symbol}`;
     const res = await fetch(url);
     const json = await res.json();
     const price = json.c ?? json.current ?? null;

--- a/env.example
+++ b/env.example
@@ -1,6 +1,8 @@
 # API Keys for stock data providers
 NEXT_PUBLIC_FINNHUB_TOKEN=your_finnhub_api_key_here
 NEXT_PUBLIC_ALPHA_VANTAGE_TOKEN=your_alphavantage_api_key_here
+# Server-side Finnhub API key. Define only on the server and never expose to the browser
+FINNHUB_API_KEY=
 
 # Optional: Analytics (if used)
 NEXT_PUBLIC_ANALYTICS_ID=


### PR DESCRIPTION
## Summary
- provide new `apps/web/app/api/quote/route.ts` for proxying realtime quotes
- update priceService to use the new route
- update legacy dashboard scripts to call `/api/quote`
- document `FINNHUB_API_KEY` in example env file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688612421acc832ea364e695665d53e7