### PR TITLE
Add candle API proxy and update services

### DIFF
--- a/apps/web/app/api/candle/route.ts
+++ b/apps/web/app/api/candle/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const search = request.nextUrl.searchParams;
+  const symbol = search.get('symbol');
+  const resolution = search.get('resolution');
+  const from = search.get('from');
+  const to = search.get('to');
+
+  if (!symbol || !resolution || !from || !to) {
+    return new Response(
+      JSON.stringify({ error: 'symbol, resolution, from and to are required' }),
+      {
+        status: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+      }
+    );
+  }
+
+  const token = process.env.FINNHUB_API_KEY;
+  if (!token) {
+    return new Response(JSON.stringify({ error: 'FINNHUB_API_KEY not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+    });
+  }
+
+  const url = `https://finnhub.io/api/v1/stock/candle?symbol=${encodeURIComponent(
+    symbol
+  )}&resolution=${encodeURIComponent(resolution)}&from=${encodeURIComponent(from)}&to=${encodeURIComponent(
+    to
+  )}&token=${token}`;
+
+  const resp = await fetch(url);
+  const data = await resp.json();
+
+  return new Response(JSON.stringify(data), {
+    status: resp.status,
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+  });
+}

--- a/apps/web/app/lib/services/priceService.ts
+++ b/apps/web/app/lib/services/priceService.ts
@@ -2,10 +2,7 @@ import { getPrice, putPrice, CachedPrice } from './dataService';
 // 所有外部 API 调用都通过 apiQueue 进行排队以防止触发速率限制
 import { apiQueue } from './apiQueue';
 
-/**
- * API 基础 URL 常量
- */
-const FINNHUB_BASE_URL = 'https://finnhub.io/api/v1';
+
 
 /**
  * 环境变量中的 API 令牌
@@ -83,7 +80,8 @@ async function fetchFinnhubDailyClose(symbol: string, date: string): Promise<num
 
   const fromTs = Math.floor(new Date(`${date}T00:00:00Z`).getTime() / 1000);
   const toTs = Math.floor(new Date(`${date}T23:59:59Z`).getTime() / 1000);
-  const url = `${FINNHUB_BASE_URL}/stock/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${fromTs}&to=${toTs}&token=${token}`;
+  // 通过内部 API 路由转发请求，避免在浏览器暴露密钥
+  const url = `/api/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${fromTs}&to=${toTs}`;
 
   try {
     // 使用 apiQueue 队列以避免触发速率限制

--- a/apps/web/public/js/services/finnhubService.js
+++ b/apps/web/public/js/services/finnhubService.js
@@ -6,14 +6,8 @@
 import { apiQueue } from './apiQueue.js';
 import { putPrice, getPrice } from '../lib/idb.js';
 
-const TOKEN_KEY = 'FINNHUB_TOKEN';
-const API_BASE  = 'https://finnhub.io/api/v1';
-
-/** Return stored token or fallback demo token */
-export function getToken(){
-  return localStorage.getItem(TOKEN_KEY) || 'd19cvm9r01qmm7tudrk0d19cvm9r01qmm7tudrkg';
-}
-
+// 使用内部 API 路由，避免在浏览器暴露密钥
+const API_BASE  = '/api';
 /**
  * Fetch daily close from Finnhub.
  * @param {string} symbol
@@ -23,7 +17,7 @@ export function getToken(){
 export async function fetchFinnhubDailyClose(symbol, date){
   const fromTs = Math.floor(new Date(date + 'T00:00:00Z').getTime()/1000);
   const toTs   = Math.floor(new Date(date + 'T23:59:59Z').getTime()/1000);
-  const url = `${API_BASE}/stock/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${fromTs}&to=${toTs}&token=${getToken()}`;
+  const url = `${API_BASE}/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${fromTs}&to=${toTs}`;
   try{
     const json = await apiQueue.enqueue(()=> fetch(url).then(r=>r.json()));
     if(json && json.c && json.c.length){


### PR DESCRIPTION
## Summary
- proxy `/api/candle` to Finnhub candle endpoint
- fetch candle data via new proxy in server price service
- use the proxy in legacy finnhub service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688628dc48a0832e9d7b057a683ca693