### PR TITLE
Add Tiingo fallback for quotes

### DIFF
--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -31,7 +31,7 @@ export interface CachedPrice {
   symbol: string;
   date: string;
   close: number;
-  source: 'finnhub' | 'alphavantage' | 'import';
+  source: 'finnhub' | 'alphavantage' | 'import' | 'tiingo';
 }
 
 // Internal representation, adapted for the app

--- a/apps/web/app/modules/PositionsTable.tsx
+++ b/apps/web/app/modules/PositionsTable.tsx
@@ -76,8 +76,7 @@ export function PositionsTable({ positions, trades }: Props) {
 
     return positions.map((pos, idx) => {
       const result = results[idx];
-      // 修改：如果lastPrice为undefined，则使用平均价格作为回退值
-      const lastPrice = result?.data !== undefined ? result.data : pos.avgPrice;
+      const lastPrice = result?.data?.price !== undefined ? result.data.price : pos.avgPrice;
 
       // 修改：对于空头持仓，市值应该是正数（使用绝对值）
       const isShort = pos.qty < 0;
@@ -141,8 +140,8 @@ export function PositionsTable({ positions, trades }: Props) {
         <tbody>
           {positions.map((pos, idx) => {
             const result = results[idx];
-            // 修改：如果lastPrice为undefined，则使用平均价格作为回退值
-            const lastPrice = result?.data !== undefined ? result.data : pos.avgPrice;
+            const lastPrice = result?.data?.price !== undefined ? result.data.price : pos.avgPrice;
+            const isStale = result?.data?.stale;
             const isLoading = result?.isLoading;
             const isError = result?.isError;
 
@@ -168,7 +167,11 @@ export function PositionsTable({ positions, trades }: Props) {
                 <td>
                   {isLoading && <span className="loading">加载中...</span>}
                   {isError && <span className="error">获取失败</span>}
-                  {!isLoading && !isError && formatNumber(lastPrice)}
+                  {!isLoading && !isError && (
+                    <span className={isStale ? 'text-gray-500' : undefined}>
+                      {formatNumber(lastPrice)}{isStale ? ' *' : ''}
+                    </span>
+                  )}
                 </td>
                 <td>{pos.qty}</td>
                 <td>{formatNumber(pos.avgPrice)}</td>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -54,14 +54,15 @@ export default function DashboardPage() {
         // 为每个持仓获取最新价格
         for (const pos of posList) {
           try {
-            let price = await fetchRealtimeQuote(pos.symbol);
-            if (!price || price === 1) {
+            let result = await fetchRealtimeQuote(pos.symbol);
+            if (!result || result.price === 1) {
               const today = new Date().toISOString().slice(0, 10);
-              price = await fetchDailyClose(pos.symbol, today);
+              result = await fetchDailyClose(pos.symbol, today);
             }
-            if (price && price !== 1) {
-              pos.last = price;
-              pos.priceOk = true;
+
+            if (result && result.price && result.price !== 1) {
+              pos.last = result.price;
+              pos.priceOk = !result.stale;
             } else {
               pos.last = NaN;
               pos.priceOk = false;
@@ -143,14 +144,14 @@ export default function DashboardPage() {
 
       for (const pos of posList) {
         try {
-          let price = await fetchRealtimeQuote(pos.symbol);
-          if (!price || price === 1) {
+          let result = await fetchRealtimeQuote(pos.symbol);
+          if (!result || result.price === 1) {
             const today = new Date().toISOString().slice(0, 10);
-            price = await fetchDailyClose(pos.symbol, today);
+            result = await fetchDailyClose(pos.symbol, today);
           }
-          if (price && price !== 1) {
-            pos.last = price;
-            pos.priceOk = true;
+          if (result && result.price && result.price !== 1) {
+            pos.last = result.price;
+            pos.priceOk = !result.stale;
           } else {
             pos.last = NaN;
             pos.priceOk = false;


### PR DESCRIPTION
## Summary
- extend cached price source to include Tiingo
- support Tiingo quotes and close prices with 5‑minute local caching
- fall back to Tiingo when Finnhub fails and mark stale quotes
- display stale quotes with an asterisk

## Testing
- `npm run check-types`
- `npm test`
- `npm run lint` *(fails: Next.js lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68863ef2e5f0832ebc4d73f79cfbe784