### PR TITLE
Document Tiingo API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Run the following command:
 npx create-turbo@latest
 ```
 
+## API Keys
+
+This project uses external stock data providers. Set your Tiingo API token in
+`NEXT_PUBLIC_TIINGO_TOKEN` (or the `KEY.txt` file for local usage) so the app
+can request quotes from Tiingo.
+
 ## What's inside?
 
 This Turborepo includes the following packages/apps:

--- a/apps/web/public/KEY.txt
+++ b/apps/web/public/KEY.txt
@@ -4,5 +4,6 @@ NEXT_PUBLIC_FINNHUB_TOKEN=d19cvm9r01qmm7tudrk0d19cvm9r01qmm7tudrkg
 Finnhub key：d19cvm9r01qmm7tudrk0d19cvm9r01qmm7tudrkg
 https://finnhub.io/docs/api 这是api说明文档
 NEXT_PUBLIC_ALPHA_VANTAGE_TOKEN=7WVA9HZ4BCR6BR30
-Alpha key：7WVA9HZ4BCR6BR30 
+Alpha key：7WVA9HZ4BCR6BR30
+NEXT_PUBLIC_TIINGO_TOKEN=a295297fc4a8990c372a17d622adb84ff71aea5f
 Tiingo key:a295297fc4a8990c372a17d622adb84ff71aea5f

--- a/env.example
+++ b/env.example
@@ -1,6 +1,7 @@
 # API Keys for stock data providers
 NEXT_PUBLIC_FINNHUB_TOKEN=your_finnhub_api_key_here
 NEXT_PUBLIC_ALPHA_VANTAGE_TOKEN=your_alphavantage_api_key_here
+NEXT_PUBLIC_TIINGO_TOKEN=your_tiingo_api_key_here
 # Server-side Finnhub API key. Define only on the server and never expose to the browser
 FINNHUB_API_KEY=
 


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_TIINGO_TOKEN placeholder in env.example
- include the Tiingo token in KEY.txt
- mention Tiingo API key setup in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68864ab232bc832ea15f03e2118ef697