### PR TITLE
Add gray utility class for stale prices

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -147,6 +147,7 @@ body {
 .green { color: var(--c-green); }
 .red   { color: var(--c-red); }
 .white { color: #ffffff; }
+.gray  { color: var(--c-gray); }
 
 .table {
   border-collapse: collapse;

--- a/apps/web/app/modules/PositionsTable.tsx
+++ b/apps/web/app/modules/PositionsTable.tsx
@@ -167,11 +167,11 @@ export function PositionsTable({ positions, trades }: Props) {
                 <td>
                   {isLoading && <span className="loading">加载中...</span>}
                   {isError && <span className="error">获取失败</span>}
-                  {!isLoading && !isError && (
-                    <span className={isStale ? 'text-gray-500' : undefined}>
-                      {formatNumber(lastPrice)}{isStale ? ' *' : ''}
-                    </span>
-                  )}
+                    {!isLoading && !isError && (
+                      <span className={isStale ? 'gray' : undefined}>
+                        {formatNumber(lastPrice)}{isStale ? ' *' : ''}
+                      </span>
+                    )}
                 </td>
                 <td>{pos.qty}</td>
                 <td>{formatNumber(pos.avgPrice)}</td>


### PR DESCRIPTION
## Summary
- add `.gray` utility style
- style stale prices in `PositionsTable` with `.gray`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68864d1b6108832e9dc32629a9fe63ef