### PR TITLE
Implement additional metric coloring

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -6,6 +6,8 @@
   --c-green: #00e676;      /* positive number */
   --c-green-alt: #05c788;  /* secondary positive */
   --c-red: #ff5252;        /* negative number */
+  --c-purple: #b388ff;     /* short position */
+  --c-blue: #40c4ff;       /* cover position */
   --c-gray: #94a3b8;       /* secondary text */
 
   /* Layout */
@@ -146,6 +148,8 @@ body {
 /* Color utility classes (legacy) */
 .green { color: var(--c-green); }
 .red   { color: var(--c-red); }
+.purple { color: var(--c-purple); }
+.blue  { color: var(--c-blue); }
 .white { color: #ffffff; }
 .gray  { color: var(--c-gray); }
 

--- a/apps/web/app/modules/DashboardMetrics.tsx
+++ b/apps/web/app/modules/DashboardMetrics.tsx
@@ -86,8 +86,13 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
         const m5 = value as Metrics['M5'];
         formattedValue = (
           <>
-            交易: {formatCurrency(m5.trade)}<br />
-            FIFO: {formatCurrency(m5.fifo)}
+            <span className={m5.trade > 0 ? 'green' : m5.trade < 0 ? 'red' : undefined}>
+              交易: {formatCurrency(m5.trade)}
+            </span>
+            <br />
+            <span className={m5.fifo > 0 ? 'green' : m5.fifo < 0 ? 'red' : undefined}>
+              FIFO: {formatCurrency(m5.fifo)}
+            </span>
           </>
         );
       }
@@ -97,14 +102,23 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
           <>
             <span className="green">B/{counts.B}</span>{' '}
             <span className="red">S/{counts.S}</span>{' '}
-            P/{counts.P} C/{counts.C}
+            <span className="purple">P/{counts.P}</span>{' '}
+            <span className="blue">C/{counts.C}</span>
             <br />【{counts.total}】
           </>
         );
       }
       else if (key === 'M10') {
         const m10 = value as Metrics['M10'];
-        formattedValue = `W/${m10.W} L/${m10.L} ${m10.rate.toFixed(1)}%`;
+        formattedValue = (
+          <>
+            <span className="green">W/{m10.W}</span>{' '}
+            <span className="red">L/{m10.L}</span>{' '}
+            <span className={m10.rate >= 50 ? 'green' : 'red'}>
+              {m10.rate.toFixed(1)}%
+            </span>
+          </>
+        );
       }
       else {
         const numValue = value as number;

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -15,6 +15,8 @@ export default {
         green: 'var(--c-green)',
         'green-alt': 'var(--c-green-alt)',
         red: 'var(--c-red)',
+        purple: 'var(--c-purple)',
+        blue: 'var(--c-blue)',
         gray: 'var(--c-gray)',
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- update CSS token palette and utility classes for purple and blue
- expose purple/blue in Tailwind theme
- color code daily metrics in `DashboardMetrics`

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68866ce6466c832e865e30a2ec0b2681