### PR TITLE
Fix metrics grid layout

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -43,7 +43,7 @@ body {
 }
 
 /* Original CSS classes from style.css */
-.section-title, .table, #symbols-list, .stats-grid {
+.section-title, .table, #symbols-list {
   width: 90%;
   max-width: var(--page-max);
   margin-left: auto;
@@ -89,11 +89,16 @@ body {
 
 /* Dashboard stats grid */
 .stats-grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: 10px;
   justify-content: center;
   margin: 20px auto;
+  width: max-content;
+}
+
+/* Default layout for dashboard metrics */
+#stats {
+  grid-template-columns: repeat(7, 180px);
 }
 
 .symbols-list {


### PR DESCRIPTION
## Summary
- center metrics grid and remove width constraint
- arrange 13 metrics as two rows (7 + 6)

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886aa9fa1e0832ea511f0ad6389a235