### PR TITLE
Fix dashboard metrics layout

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -96,10 +96,6 @@ body {
   width: max-content;
 }
 
-/* Default layout for dashboard metrics */
-#stats {
-  grid-template-columns: repeat(7, 180px);
-}
 
 .symbols-list {
   display: flex;

--- a/apps/web/app/modules/DashboardMetrics.tsx
+++ b/apps/web/app/modules/DashboardMetrics.tsx
@@ -140,15 +140,37 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
   }, [metrics, metricNames, order]);
 
   return (
-    <section id="stats" className="stats-grid">
-      {formattedMetrics.map(metric => (
-        <MetricCard
-          key={metric.key}
-          title={metric.title}
-          value={metric.value}
-          colorClass={metric.colorClass}
-        />
-      ))}
+    <section id="stats" className="flex flex-col items-center gap-2.5 my-5">
+      <div className="flex justify-center gap-2.5">
+        {formattedMetrics.slice(0, 5).map(metric => (
+          <MetricCard
+            key={metric.key}
+            title={metric.title}
+            value={metric.value}
+            colorClass={metric.colorClass}
+          />
+        ))}
+      </div>
+      <div className="flex justify-center gap-2.5">
+        {formattedMetrics.slice(5, 10).map(metric => (
+          <MetricCard
+            key={metric.key}
+            title={metric.title}
+            value={metric.value}
+            colorClass={metric.colorClass}
+          />
+        ))}
+      </div>
+      <div className="flex justify-center gap-2.5">
+        {formattedMetrics.slice(10).map(metric => (
+          <MetricCard
+            key={metric.key}
+            title={metric.title}
+            value={metric.value}
+            colorClass={metric.colorClass}
+          />
+        ))}
+      </div>
     </section>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- adjust metrics layout to three centered rows
- drop unused #stats grid CSS

## Testing
- `npm install` *(fails: registry.npmmirror.com blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886b259e9e4832e85057c195b68f494