### PR TITLE
Fix timezone for metrics date

### DIFF
--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -1,5 +1,6 @@
 import type { EnrichedTrade } from "@/lib/fifo";
 import type { Position } from '@/lib/services/dataService';
+import { nowNY } from '@/lib/timezone';
 
 /**
  * 交易系统指标接口
@@ -644,8 +645,8 @@ export function calcMetrics(
   positions: Position[],
   dailyResults: DailyResult[] = []
 ): Metrics {
-  // 获取今日日期字符串
-  const todayStr = new Date().toISOString().slice(0, 10);
+  // 获取今日日期字符串（纽约时区）
+  const todayStr = nowNY().toISOString().slice(0, 10);
 
   // M1: 持仓成本
   const totalCost = sum(positions.map(p => p.avgPrice * Math.abs(p.qty)));


### PR DESCRIPTION
## Summary
- ensure `calcMetrics` uses New York timezone by default

## Testing
- `npm run lint` *(fails: command exited with code 1)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688746a2681c832eafd0e7fe58e8c74c