### PR TITLE
fix: allow overriding positions

### DIFF
--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -127,7 +127,7 @@ export async function importData(rawData: { positions: Position[], trades: RawTr
 
   // Import positions
   const positionStore = tx.objectStore(POSITIONS_STORE_NAME);
-  const positionPromises = rawData.positions.map(position => positionStore.add(position));
+  const positionPromises = rawData.positions.map(position => positionStore.put(position));
 
   await Promise.all([...tradePromises, ...positionPromises]);
   await tx.done;


### PR DESCRIPTION
## Summary
- allow importing position records with existing symbols by using `put`

## Testing
- `node --loader ts-node/esm <<'NODE'\nimport 'fake-indexeddb/auto';\nimport { importData, clearAllData } from './apps/web/app/lib/services/dataService.ts';\n\nconst raw = {\n  positions: [{symbol: 'AAPL', qty: 10, avgPrice: 150, last: 155, priceOk: true}],\n  trades: []\n};\n\nawait clearAllData();\nawait importData(raw);\nawait importData(raw);\nconsole.log('importData invoked twice without errors');\nNODE`
- `npm test -- --silent`

------
https://chatgpt.com/codex/tasks/task_e_688e4f637740832e9f12d6a23cc7678c