### PR TITLE
fix: reset prices object store when upgrading

### DIFF
--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -1,7 +1,7 @@
 import { openDB, DBSchema, IDBPDatabase } from 'idb';
 
 const DB_NAME = 'TradingApp';
-const DB_VERSION = 2; // Incremented version for schema change
+const DB_VERSION = 3; // Incremented version for schema change
 const TRADES_STORE_NAME = 'trades';
 const POSITIONS_STORE_NAME = 'positions';
 const PRICES_STORE_NAME = 'prices'; // New store for prices
@@ -80,13 +80,14 @@ function getDb(): Promise<IDBPDatabase<TradingDB>> {
             db.createObjectStore(POSITIONS_STORE_NAME, { keyPath: 'symbol' });
           }
         }
-        if (oldVersion < 2) {
-          if (!db.objectStoreNames.contains(PRICES_STORE_NAME)) {
-            const store = db.createObjectStore(PRICES_STORE_NAME, {
-              keyPath: ['symbol', 'date'],
-            });
-            store.createIndex('by-symbol', 'symbol');
+        if (oldVersion < 3) {
+          if (db.objectStoreNames.contains(PRICES_STORE_NAME)) {
+            db.deleteObjectStore(PRICES_STORE_NAME);
           }
+          const store = db.createObjectStore(PRICES_STORE_NAME, {
+            keyPath: ['symbol', 'date'],
+          });
+          store.createIndex('by-symbol', 'symbol');
         }
       },
     });


### PR DESCRIPTION
## Summary
- rebuild prices object store during migrations to ensure composite key schema
- bump IndexedDB version to trigger migration

## Testing
- `npm test`
- `npx -y tsx temp-script.ts` *(manual check of price import/export)*

------
https://chatgpt.com/codex/tasks/task_e_688e5f91e294832e8aff26a6c9025c56