### PR TITLE
fix: rebuild prices store during migration

### DIFF
--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -1,7 +1,7 @@
 import { openDB, DBSchema, IDBPDatabase } from 'idb';
 
 const DB_NAME = 'TradingApp';
-const DB_VERSION = 2; // Incremented version for schema change
+const DB_VERSION = 3; // Incremented version for schema change
 const TRADES_STORE_NAME = 'trades';
 const POSITIONS_STORE_NAME = 'positions';
 const PRICES_STORE_NAME = 'prices'; // New store for prices
@@ -81,12 +81,13 @@ function getDb(): Promise<IDBPDatabase<TradingDB>> {
           }
         }
         if (oldVersion < 2) {
-          if (!db.objectStoreNames.contains(PRICES_STORE_NAME)) {
-            const store = db.createObjectStore(PRICES_STORE_NAME, {
-              keyPath: ['symbol', 'date'],
-            });
-            store.createIndex('by-symbol', 'symbol');
+          if (db.objectStoreNames.contains(PRICES_STORE_NAME)) {
+            db.deleteObjectStore(PRICES_STORE_NAME);
           }
+          const store = db.createObjectStore(PRICES_STORE_NAME, {
+            keyPath: ['symbol', 'date'],
+          });
+          store.createIndex('by-symbol', 'symbol');
         }
       },
     });


### PR DESCRIPTION
## Summary
- recreate `prices` object store during upgrades and add `by-symbol` index
- bump IndexedDB version to 3 for schema migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e6467e3a8832e9bfc3fe892d20baa