### PR TITLE
chore: allow FINNHUB_API_KEY in turbo builds

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
+  "globalEnv": ["FINNHUB_API_KEY"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- ensure turbo forwards FINNHUB_API_KEY during build

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688e8119e968832e944ea3355c651657