### PR TITLE
fix: guard against missing trade dates

### DIFF
--- a/apps/web/app/lib/calcTodayTradePnL.ts
+++ b/apps/web/app/lib/calcTodayTradePnL.ts
@@ -16,7 +16,8 @@ export function calcTodayTradePnL(enrichedTrades: EnrichedTrade[], todayStr: str
 
   // 按时间顺序处理今日交易
   enrichedTrades
-    .filter(t => t.date.startsWith(todayStr))
+    // Some trade records may miss the date field; guard to prevent runtime errors
+    .filter(t => t.date?.startsWith(todayStr))
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .forEach(t => {
       const { symbol, action, quantity, price } = t;

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -234,7 +234,8 @@ function calcTodayFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): nu
 
   // 3. 构建历史FIFO栈
   enrichedTrades
-    .filter(t => !t.date.startsWith(todayStr))
+    // Guard against trades without a valid date string
+    .filter(t => !t.date?.startsWith(todayStr))
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .forEach(t => {
       const { symbol, action, quantity, price, date } = t;
@@ -558,7 +559,7 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
     if (action === 'buy') {
       if (!longFifo[symbol]) longFifo[symbol] = [];
       longFifo[symbol].push({ qty: quantity });
-      if (date.startsWith(todayStr)) B++;
+      if (date?.startsWith(todayStr)) B++;
     } else if (action === 'sell') {
       let remain = quantity;
       const fifo = longFifo[symbol] || [];
@@ -567,18 +568,18 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
         const q = Math.min(lot.qty, remain);
         lot.qty -= q;
         remain -= q;
-        if (date.startsWith(todayStr)) S++;
+        if (date?.startsWith(todayStr)) S++;
         if (lot.qty === 0) fifo.shift();
       }
       if (remain > 0) {
         if (!shortFifo[symbol]) shortFifo[symbol] = [];
         shortFifo[symbol].push({ qty: remain });
-        if (date.startsWith(todayStr)) P++;
+        if (date?.startsWith(todayStr)) P++;
       }
     } else if (action === 'short') {
       if (!shortFifo[symbol]) shortFifo[symbol] = [];
       shortFifo[symbol].push({ qty: quantity });
-      if (date.startsWith(todayStr)) P++;
+      if (date?.startsWith(todayStr)) P++;
     } else if (action === 'cover') {
       let remain = quantity;
       const fifo = shortFifo[symbol] || [];
@@ -587,13 +588,13 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
         const q = Math.min(lot.qty, remain);
         lot.qty -= q;
         remain -= q;
-        if (date.startsWith(todayStr)) C++;
+        if (date?.startsWith(todayStr)) C++;
         if (lot.qty === 0) fifo.shift();
       }
       if (remain > 0) {
         if (!longFifo[symbol]) longFifo[symbol] = [];
         longFifo[symbol].push({ qty: remain });
-        if (date.startsWith(todayStr)) B++;
+        if (date?.startsWith(todayStr)) B++;
       }
     }
   }

--- a/apps/web/scripts/generateDailyResult.ts
+++ b/apps/web/scripts/generateDailyResult.ts
@@ -8,7 +8,8 @@ import type { DailyResult } from '../app/lib/metrics';
  */
 export function generateDailyResult(trades: EnrichedTrade[], date: string): DailyResult {
   const realized = trades
-    .filter(t => t.date.startsWith(date))
+    // Ensure trade has a valid date before checking prefix
+    .filter(t => t.date?.startsWith(date))
     .reduce((acc, t) => acc + (t.realizedPnl || 0), 0);
 
   const float = 0; // 浮动盈亏由外部价格数据计算，此处置零占位


### PR DESCRIPTION
## Summary
- prevent runtime crashes when trades lack a date by using optional chaining
- apply date guards in metrics and daily result generation

## Testing
- `npx -y jest` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e84aebfa8832eb970fe6f92f3fa64