### PR TITLE
refactor: run memoized metrics on every render

### DIFF
--- a/apps/web/app/modules/DashboardMetrics.tsx
+++ b/apps/web/app/modules/DashboardMetrics.tsx
@@ -44,16 +44,6 @@ function MetricCard({
 export function DashboardMetrics({ enrichedTrades, positions }: Props) {
   // 从全局状态获取指标
   const metrics = useStore((state) => state.metrics);
-
-  // 如果指标未加载，显示加载中
-  if (!metrics) {
-    return (
-      <section id="stats" className="stats-grid">
-        正在加载指标...
-      </section>
-    );
-  }
-
   // 定义指标名称映射
   const metricNames: Record<keyof Metrics, string> = useMemo(
     () => ({
@@ -96,6 +86,8 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
 
   // 格式化指标值并确定颜色
   const formattedMetrics = useMemo(() => {
+    if (!metrics) return [];
+
     return order.map((key) => {
       const value = metrics[key];
       let formattedValue: ReactNode;
@@ -167,6 +159,15 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
       };
     });
   }, [metrics, metricNames, order]);
+
+  // 如果指标未加载，显示加载中
+  if (!metrics) {
+    return (
+      <section id="stats" className="stats-grid">
+        正在加载指标...
+      </section>
+    );
+  }
 
   return (
     <section id="stats" className="my-5">


### PR DESCRIPTION
## Summary
- call metric memorization hooks before early return
- guard formatted metrics from missing data

## Testing
- `npm test`
- `npm run lint` *(fails: next lint --max-warnings 0)*

------
https://chatgpt.com/codex/tasks/task_e_688f48a4fb10832eab2cd124aaa45f21