### PR TITLE
Handle unknown trade actions

### DIFF
--- a/apps/web/app/components/AddTradeModal.tsx
+++ b/apps/web/app/components/AddTradeModal.tsx
@@ -58,7 +58,10 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
     if (trade) {
       console.log('[AddTradeModal] 编辑模式载入:', trade);
       setSymbol(trade.symbol);
-      setSide(trade.action.toUpperCase() as 'BUY' | 'SELL' | 'SHORT' | 'COVER');
+      if (!trade.action) {
+        console.warn('Editing trade has invalid action, defaulting to BUY.');
+      }
+      setSide((trade.action ? trade.action.toUpperCase() : 'BUY') as 'BUY' | 'SELL' | 'SHORT' | 'COVER');
       setQty(trade.quantity);
       setPrice(trade.price);
 

--- a/apps/web/app/modules/TradesTable.tsx
+++ b/apps/web/app/modules/TradesTable.tsx
@@ -20,7 +20,8 @@ export function TradesTable({ trades }: { trades: EnrichedTrade[] }) {
 
   const weekdayMap = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
-  const sortedRecent = [...trades]
+  const validTrades = trades.filter(t => !!t.action);
+  const sortedRecent = [...validTrades]
     .sort((a, b) => toNY(b.date).getTime() - toNY(a.date).getTime())
     .slice(0, 100);
 
@@ -44,7 +45,11 @@ export function TradesTable({ trades }: { trades: EnrichedTrade[] }) {
         {sortedRecent.map((trade, idx) => {
           const dateObj = toNY(trade.date);
           const weekday = weekdayMap[dateObj.getUTCDay()];
-          const colorSide = (trade.action === 'buy' || trade.action === 'cover') ? 'green' : 'red';
+          const colorSide = (trade.action === 'buy' || trade.action === 'cover')
+            ? 'green'
+            : (trade.action === 'sell' || trade.action === 'short')
+              ? 'red'
+              : 'white';
           const qtyColor = colorSide;
           const amount = trade.price * trade.quantity;
           return (
@@ -54,7 +59,7 @@ export function TradesTable({ trades }: { trades: EnrichedTrade[] }) {
               <td><img className="logo" src={`/logos/${trade.symbol}.png`} alt={trade.symbol} /></td>
               <td>{trade.symbol}</td>
               <td className="cn">{nameMap[trade.symbol] || '--'}</td>
-              <td className={colorSide}>{trade.action.toUpperCase()}</td>
+              <td className={colorSide}>{trade.action ? trade.action.toUpperCase() : 'UNKNOWN'}</td>
               <td>{formatNumber(trade.price)}</td>
               <td className={qtyColor}>{trade.quantity}</td>
               <td>{formatNumber(amount)}</td>

--- a/apps/web/app/trades/page.tsx
+++ b/apps/web/app/trades/page.tsx
@@ -17,7 +17,11 @@ export default function TradesPage() {
       try {
         setIsLoading(true);
         const fetchedTrades = await findTrades();
-        setTrades(computeFifo(fetchedTrades));
+        const validTrades = fetchedTrades.filter(t => !!t.action);
+        if (validTrades.length !== fetchedTrades.length) {
+          console.warn('Some trades have invalid action and were skipped.');
+        }
+        setTrades(computeFifo(validTrades));
 
         // 加载中文名称
         fetch('/data/symbol_name_map.json')
@@ -35,7 +39,11 @@ export default function TradesPage() {
 
   const reload = async () => {
     const fetched = await findTrades();
-    setTrades(computeFifo(fetched));
+    const valid = fetched.filter(t => !!t.action);
+    if (valid.length !== fetched.length) {
+      console.warn('Some trades have invalid action and were skipped.');
+    }
+    setTrades(computeFifo(valid));
   };
 
   function formatNumber(value: number | undefined, decimals = 2) {
@@ -75,7 +83,7 @@ export default function TradesPage() {
           {trades.map((trade, idx) => {
             const dateObj = toNY(trade.date);
             const weekday = weekdayMap[dateObj.getUTCDay()];
-            const sideCls = getSideClass(trade.action);
+            const sideCls = getSideClass(trade.action || '');
             const amt = trade.price * trade.quantity;
             const pnlCls = (trade.realizedPnl || 0) > 0 ? 'green' : (trade.realizedPnl || 0) < 0 ? 'red' : 'white';
 
@@ -88,7 +96,7 @@ export default function TradesPage() {
                 <td>{trade.date}</td>
                 <td>{weekday}</td>
                 <td>{trade.tradeCount}</td>
-                <td className={sideCls}>{trade.action.toUpperCase()}</td>
+                <td className={sideCls}>{trade.action ? trade.action.toUpperCase() : 'UNKNOWN'}</td>
                 <td>{formatNumber(trade.price)}</td>
                 <td className={sideCls}>{trade.quantity}</td>
                 <td>{formatNumber(amt)}</td>


### PR DESCRIPTION
## Summary
- Guard against unknown trade sides when importing data
- Display `UNKNOWN` for trades missing action across views
- Warn users when editing trades with invalid action values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f70ad6940832e8f8289767eb4906f