### PR TITLE
Handle empty trade lists

### DIFF
--- a/apps/web/app/modules/TradesTable.tsx
+++ b/apps/web/app/modules/TradesTable.tsx
@@ -18,9 +18,17 @@ export function TradesTable({ trades }: { trades: EnrichedTrade[] }) {
       .catch(() => { });
   }, []);
 
+  const invalidTrades = trades.filter(t => !t.action);
+  if (invalidTrades.length) {
+    console.warn('Invalid trades passed to TradesTable:', invalidTrades);
+  }
+  const validTrades = trades.filter(t => !!t.action);
+  if (validTrades.length === 0) {
+    return <div className="text-center p-4">No trades available or import failed.</div>;
+  }
+
   const weekdayMap = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
-  const validTrades = trades.filter(t => !!t.action);
   const sortedRecent = [...validTrades]
     .sort((a, b) => toNY(b.date).getTime() - toNY(a.date).getTime())
     .slice(0, 100);
@@ -70,4 +78,4 @@ export function TradesTable({ trades }: { trades: EnrichedTrade[] }) {
       </tbody>
     </table>
   );
-} 
+}

--- a/apps/web/app/trades/page.tsx
+++ b/apps/web/app/trades/page.tsx
@@ -17,9 +17,13 @@ export default function TradesPage() {
       try {
         setIsLoading(true);
         const fetchedTrades = await findTrades();
+        const invalidTrades = fetchedTrades.filter(t => !t.action);
+        if (invalidTrades.length) {
+          console.warn('Invalid trades encountered and skipped:', invalidTrades);
+        }
         const validTrades = fetchedTrades.filter(t => !!t.action);
-        if (validTrades.length !== fetchedTrades.length) {
-          console.warn('Some trades have invalid action and were skipped.');
+        if (validTrades.length === 0) {
+          console.info('No valid trades found in fetched data');
         }
         setTrades(computeFifo(validTrades));
 
@@ -39,9 +43,13 @@ export default function TradesPage() {
 
   const reload = async () => {
     const fetched = await findTrades();
+    const invalid = fetched.filter(t => !t.action);
+    if (invalid.length) {
+      console.warn('Invalid trades encountered and skipped:', invalid);
+    }
     const valid = fetched.filter(t => !!t.action);
-    if (valid.length !== fetched.length) {
-      console.warn('Some trades have invalid action and were skipped.');
+    if (valid.length === 0) {
+      console.info('No valid trades found when reloading');
     }
     setTrades(computeFifo(valid));
   };
@@ -55,6 +63,10 @@ export default function TradesPage() {
 
   if (isLoading) {
     return <div className="text-center p-10">Loading trades...</div>;
+  }
+
+  if (trades.length === 0) {
+    return <div className="text-center p-10">No trades available or import failed.</div>;
   }
 
   // helper for side class


### PR DESCRIPTION
## Summary
- show user message when trades data is empty
- log invalid trades for easier diagnostics

## Testing
- `npx jest --silent`
- `npm run lint` *(fails: next lint --max-warnings 0)*

------
https://chatgpt.com/codex/tasks/task_e_688f76805184832ea63492cda8d9f3b8