### PR TITLE
fix: handle missing trade action

### DIFF
--- a/apps/web/components/AddTradeModal.tsx
+++ b/apps/web/components/AddTradeModal.tsx
@@ -25,7 +25,11 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
       console.log('编辑交易:', trade);
       setSymbol(trade.symbol);
       // 将action转换为大写，确保匹配Side类型
-      setSide(trade.action.toUpperCase() as Side);
+      const action = trade.action;
+      if (!action) {
+        console.warn('Trade action missing, defaulting to BUY');
+      }
+      setSide((action ?? 'BUY').toUpperCase() as Side);
       setQty(trade.quantity);
       setPrice(trade.price);
 


### PR DESCRIPTION
## Summary
- handle missing trade.action in AddTradeModal with default BUY and warning

## Testing
- `npm test`
- `npm run lint` *(fails: command (/workspace/Trading777/apps/web) /root/.nvm/versions/node/v20.19.4/bin/npm run lint exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_688f767d7070832eb5253cdfcddce2bf