### PR TITLE
Handle malformed trades in data import

### DIFF
--- a/apps/web/app/lib/services/dataService.test.ts
+++ b/apps/web/app/lib/services/dataService.test.ts
@@ -1,0 +1,79 @@
+import "fake-indexeddb/auto";
+import { openDB } from "idb";
+import { importData, clearAndImportData, closeDb } from "./dataService";
+
+describe("dataService trade import", () => {
+  beforeEach(async () => {
+    await indexedDB.deleteDatabase("TradingApp");
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  test("importData skips malformed trades without aborting", async () => {
+    const rawData = {
+      positions: [],
+      trades: [
+        {
+          date: "2025-01-01",
+          symbol: "AAPL",
+          side: "BUY",
+          qty: 10,
+          price: 100,
+        },
+        {
+          date: "2025-01-02",
+          symbol: "MSFT",
+          side: "INVALID" as any,
+          qty: 5,
+          price: 200,
+        },
+        // @ts-expect-error intentionally missing side
+        { date: "2025-01-03", symbol: "TSLA", qty: 3, price: 300 },
+        {
+          date: "2025-01-04",
+          symbol: "GOOG",
+          side: "SELL",
+          qty: 2,
+          price: 150,
+        },
+      ],
+    };
+
+    await importData(rawData);
+    const db = await openDB("TradingApp", 3);
+    const trades = await db.getAll("trades");
+    db.close();
+    expect(trades).toHaveLength(2);
+  });
+
+  test("clearAndImportData skips malformed trades", async () => {
+    const rawData = {
+      positions: [],
+      trades: [
+        {
+          date: "2025-02-01",
+          symbol: "MSFT",
+          side: "INVALID" as any,
+          qty: 1,
+          price: 200,
+        },
+        {
+          date: "2025-02-02",
+          symbol: "GOOG",
+          side: "SELL",
+          qty: 1,
+          price: 150,
+        },
+      ],
+    };
+
+    await clearAndImportData(rawData);
+    const db = await openDB("TradingApp", 3);
+    const trades = await db.getAll("trades");
+    db.close();
+    expect(trades).toHaveLength(1);
+    expect(trades[0]).toMatchObject({ symbol: "GOOG", action: "sell" });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "fake-indexeddb": "^6.0.1",
         "jest": "^30.0.5",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.0",
@@ -5460,6 +5461,16 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "fake-indexeddb": "^6.0.1",
     "jest": "^30.0.5",
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.0",


### PR DESCRIPTION
## Summary
- validate trade side before importing and skip malformed entries
- add DB cleanup helper
- test that data import ignores malformed trades

## Testing
- `npm test`
- `npm run lint` *(fails: command /root/.nvm/versions/node/v20.19.4/bin/npm run lint exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_688f76692f3c832eb76d3419621462d1