### PR TITLE
fix metrics total cost sign

### DIFF
--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -417,7 +417,7 @@ export function calcMetrics(
   const todayStr = nowNY().toISOString().slice(0, 10);
 
   // M1: 持仓成本
-  const totalCost = sum(positions.map(p => p.avgPrice * Math.abs(p.qty)));
+  const totalCost = sum(positions.map(p => Math.abs(p.avgPrice * p.qty)));
 
   // M2: 持仓市值
   if (DEBUG) console.log('计算M2(持仓市值)，持仓数据:', positions);


### PR DESCRIPTION
## Summary
- ensure position cost calculation remains positive regardless of avg price or quantity sign

## Testing
- `npm test`
- `npm run lint` *(fails: Using `<img>` could result in slower LCP and higher bandwidth...)*

------
https://chatgpt.com/codex/tasks/task_e_688fa8277d1c832eb65dbdf3e9a94584