### PR TITLE
Normalize PnL calculation to use absolute quantity

### DIFF
--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -430,12 +430,13 @@ export function calcMetrics(
 
   // M3: 持仓浮盈
   const floatPnl = positions.reduce((acc, pos) => {
+    const qty = Math.abs(pos.qty);
     if (pos.qty >= 0) {
-      // 多头: 市值 - 成本
-      return acc + (pos.last * pos.qty - pos.avgPrice * pos.qty);
+      // 多头: (市价 - 均价) * 数量
+      return acc + (pos.last - pos.avgPrice) * qty;
     } else {
-      // 空头: 成本 - 市值的绝对值
-      return acc + (pos.avgPrice * Math.abs(pos.qty) - Math.abs(pos.last * pos.qty));
+      // 空头: (均价 - 市价) * 数量
+      return acc + (pos.avgPrice - pos.last) * qty;
     }
   }, 0);
 


### PR DESCRIPTION
## Summary
- normalize position quantity when computing float profit
- handle long and short float PnL using (last - avgPrice) and (avgPrice - last)

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688faa44d2a0832ea06c3b4b9ab1cdba