### PR TITLE
Skip demo trade import after custom dataset

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -25,12 +25,14 @@ export default function DashboardPage() {
     async function loadData() {
       try {
         setIsLoading(true);
-        const response = await fetch('/trades.json');
-        if (!response.ok) {
-          throw new Error('Failed to fetch trades.json');
+        if (!localStorage.getItem('customTradesLoaded')) {
+          const response = await fetch('/trades.json');
+          if (!response.ok) {
+            throw new Error('Failed to fetch trades.json');
+          }
+          const rawData = await response.json();
+          await importData(rawData);
         }
-        const rawData = await response.json();
-        await importData(rawData);
 
         const dbTrades = await findTrades();
         const enriched = computeFifo(dbTrades);

--- a/apps/web/app/positions/page.tsx
+++ b/apps/web/app/positions/page.tsx
@@ -18,10 +18,12 @@ export default function PositionsPage() {
       try {
         setIsLoading(true);
         // 初次使用时导入数据（若已存在则自动跳过）
-        const response = await fetch('/trades.json');
-        if (response.ok) {
-          const rawData = await response.json();
-          await importData(rawData);
+        if (!localStorage.getItem('customTradesLoaded')) {
+          const response = await fetch('/trades.json');
+          if (response.ok) {
+            const rawData = await response.json();
+            await importData(rawData);
+          }
         }
 
         const allTrades = await findTrades();

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -12,10 +12,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     async function initData() {
       try {
-        const res = await fetch('/trades.json');
-        if (res.ok) {
-          const raw = await res.json();
-          await importData(raw); // skip if already exist
+        if (!localStorage.getItem('customTradesLoaded')) {
+          const res = await fetch('/trades.json');
+          if (res.ok) {
+            const raw = await res.json();
+            await importData(raw); // skip if already exist
+          }
         }
       } catch (_) {
         // optional: ignore errors when demo file missing

--- a/apps/web/components/layout/Header.tsx
+++ b/apps/web/components/layout/Header.tsx
@@ -76,6 +76,7 @@ export function Header() {
         }
 
         await clearAndImportData(data);
+        localStorage.setItem('customTradesLoaded', 'true');
         alert('导入成功! 页面将刷新。');
         window.location.reload();
       } catch (err) {


### PR DESCRIPTION
## Summary
- only import demo trades when `customTradesLoaded` flag is missing
- store `customTradesLoaded` flag after clearing & importing user data
- respect the custom data flag when pages fetch demo trades

## Testing
- `npm test`
- `npm run lint` *(fails: multiple lint warnings)*


------
https://chatgpt.com/codex/tasks/task_e_688fad8ab550832e992aff66280dc396