### PR TITLE
Always import trades on startup

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -25,14 +25,12 @@ export default function DashboardPage() {
     async function loadData() {
       try {
         setIsLoading(true);
-        if (!localStorage.getItem('customTradesLoaded')) {
-          const response = await fetch('/trades.json');
-          if (!response.ok) {
-            throw new Error('Failed to fetch trades.json');
-          }
-          const rawData = await response.json();
-          await importData(rawData);
+        const response = await fetch('/trades.json');
+        if (!response.ok) {
+          throw new Error('Failed to fetch trades.json');
         }
+        const rawData = await response.json();
+        await importData(rawData);
 
         const dbTrades = await findTrades();
         const enriched = computeFifo(dbTrades);

--- a/apps/web/app/positions/page.tsx
+++ b/apps/web/app/positions/page.tsx
@@ -18,12 +18,10 @@ export default function PositionsPage() {
       try {
         setIsLoading(true);
         // 初次使用时导入数据（若已存在则自动跳过）
-        if (!localStorage.getItem('customTradesLoaded')) {
-          const response = await fetch('/trades.json');
-          if (response.ok) {
-            const rawData = await response.json();
-            await importData(rawData);
-          }
+        const response = await fetch('/trades.json');
+        if (response.ok) {
+          const rawData = await response.json();
+          await importData(rawData);
         }
 
         const allTrades = await findTrades();

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -12,12 +12,10 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     async function initData() {
       try {
-        if (!localStorage.getItem('customTradesLoaded')) {
-          const res = await fetch('/trades.json');
-          if (res.ok) {
-            const raw = await res.json();
-            await importData(raw); // skip if already exist
-          }
+        const res = await fetch('/trades.json');
+        if (res.ok) {
+          const raw = await res.json();
+          await importData(raw); // skip if already exist
         }
       } catch (_) {
         // optional: ignore errors when demo file missing

--- a/apps/web/components/layout/Header.tsx
+++ b/apps/web/components/layout/Header.tsx
@@ -76,7 +76,6 @@ export function Header() {
         }
 
         await clearAndImportData(data);
-        localStorage.setItem('customTradesLoaded', 'true');
         alert('导入成功! 页面将刷新。');
         window.location.reload();
       } catch (err) {


### PR DESCRIPTION
## Summary
- Remove `customTradesLoaded` localStorage checks and always import `/trades.json` at startup
- Drop `localStorage` flag from manual import and reload after import

## Testing
- `npm test`
- `npm run lint` *(fails: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` ...)*

------
https://chatgpt.com/codex/tasks/task_e_688fb4dd94b8832ebf393354df898986