### PR TITLE
feat: skip sample import when trades exist

### DIFF
--- a/apps/web/app/positions/page.tsx
+++ b/apps/web/app/positions/page.tsx
@@ -1,11 +1,11 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { importData } from '@/lib/services/dataService';
-import { findTrades } from '@/lib/services/dataService';
-import type { Position } from '@/lib/services/dataService';
-import { computeFifo, type EnrichedTrade } from '@/lib/fifo';
-import { PositionsTable } from '@/modules/PositionsTable';
+import { useEffect, useState } from "react";
+import { importData } from "@/lib/services/dataService";
+import { findTrades } from "@/lib/services/dataService";
+import type { Position } from "@/lib/services/dataService";
+import { computeFifo, type EnrichedTrade } from "@/lib/fifo";
+import { PositionsTable } from "@/modules/PositionsTable";
 
 export default function PositionsPage() {
   const [positions, setPositions] = useState<Position[]>([]);
@@ -17,14 +17,18 @@ export default function PositionsPage() {
     async function loadData() {
       try {
         setIsLoading(true);
-        // 初次使用时导入数据（若已存在则自动跳过）
-        const response = await fetch('/trades.json');
-        if (response.ok) {
-          const rawData = await response.json();
-          await importData(rawData);
+
+        // 先查询是否已有交易数据，若没有则导入示例数据
+        let allTrades = await findTrades();
+        if (allTrades.length === 0) {
+          const response = await fetch("/trades.json");
+          if (response.ok) {
+            const rawData = await response.json();
+            await importData(rawData);
+            allTrades = await findTrades();
+          }
         }
 
-        const allTrades = await findTrades();
         const enriched = computeFifo(allTrades);
         setTrades(enriched);
 
@@ -34,7 +38,7 @@ export default function PositionsPage() {
           lastMap[t.symbol] = t; // 由于 computeFifo 已按日期升序，遍历结束时即为最后状态
         }
 
-        const posList: Position[] = Object.values(lastMap).map(t => ({
+        const posList: Position[] = Object.values(lastMap).map((t) => ({
           symbol: t.symbol,
           qty: t.quantityAfter,
           avgPrice: t.averageCost,
@@ -45,7 +49,7 @@ export default function PositionsPage() {
         setPositions(posList);
       } catch (e) {
         console.error(e);
-        setError(e instanceof Error ? e.message : 'An unknown error occurred.');
+        setError(e instanceof Error ? e.message : "An unknown error occurred.");
       } finally {
         setIsLoading(false);
       }
@@ -64,8 +68,10 @@ export default function PositionsPage() {
 
   return (
     <main className="container mx-auto p-4">
-      <h1 className="text-3xl font-bold tracking-tight mb-8">Current Positions</h1>
+      <h1 className="text-3xl font-bold tracking-tight mb-8">
+        Current Positions
+      </h1>
       <PositionsTable positions={positions} trades={trades} />
     </main>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- skip sample trade import when existing trades are present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fba46dc04832eb9f8512b071e7be2