### PR TITLE
feat: support initial positions in fifo

### DIFF
--- a/apps/web/app/lib/fifo.test.ts
+++ b/apps/web/app/lib/fifo.test.ts
@@ -34,4 +34,20 @@ describe('computeFifo', () => {
     expect(tsla.quantityAfter).toBe(0);
     expect(tsla.averageCost).toBe(0);
   });
+
+  it('handles partial closes and new positions from initial state', () => {
+    const trades: Trade[] = [
+      { symbol: 'AAPL', price: 12, quantity: 50, date: '2024-01-02', action: 'sell' },
+      { symbol: 'AAPL', price: 8, quantity: 50, date: '2024-01-03', action: 'buy' },
+    ];
+    const initial: InitialPosition[] = [
+      { symbol: 'AAPL', qty: 100, avgPrice: 10 },
+    ];
+    const result = computeFifo(trades, initial);
+    expect(result.map(t => t.realizedPnl)).toEqual([100, 0]);
+    expect(result.map(t => t.quantityAfter)).toEqual([50, 100]);
+    const second = result[1]!;
+    expect(second.averageCost).toBe(9);
+    expect(second.breakEvenPrice).toBe(8);
+  });
 });

--- a/apps/web/app/lib/fifo.ts
+++ b/apps/web/app/lib/fifo.ts
@@ -40,6 +40,7 @@ export function computeFifo(
 
   for (const pos of initialPositions) {
     const quantity = Math.abs(pos.qty);
+    if (quantity <= EPSILON) continue;
     symbolStateMap[pos.symbol] = {
       positionList: [{ price: pos.avgPrice, quantity }],
       direction: pos.qty < 0 ? 'SHORT' : 'LONG',

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { importData, findTrades, clearAllData, findPositions } from '@/lib/services/dataService';
 import type { Trade, Position } from '@/lib/services/dataService';
-import { computeFifo } from '@/lib/fifo';
+import { computeFifo, type InitialPosition } from '@/lib/fifo';
 import { DashboardMetrics } from '@/modules/DashboardMetrics';
 import { PositionsTable } from '@/modules/PositionsTable';
 import { TradesTable } from '@/modules/TradesTable';
@@ -38,7 +38,7 @@ async function computeDataHash(data: unknown): Promise<string> {
 export default function DashboardPage() {
   const [trades, setTrades] = useState<Trade[]>([]);
   const [positions, setPositions] = useState<Position[]>([]);
-  const [initialPositions, setInitialPositions] = useState<Position[]>([]);
+  const [initialPositions, setInitialPositions] = useState<InitialPosition[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
@@ -143,7 +143,7 @@ export default function DashboardPage() {
 
         setTrades(dbTrades);
         setPositions(posList);
-        setInitialPositions(dbPositions);
+        setInitialPositions(dbPositions.map(({ symbol, qty, avgPrice }) => ({ symbol, qty, avgPrice })));
       } catch (e) {
         console.error(e);
         setError(e instanceof Error ? e.message : 'An unknown error occurred.');
@@ -228,7 +228,7 @@ export default function DashboardPage() {
 
       setTrades(dbTrades);
       setPositions(posList);
-      setInitialPositions(dbPositions);
+      setInitialPositions(dbPositions.map(({ symbol, qty, avgPrice }) => ({ symbol, qty, avgPrice })));
     } catch (e) { console.error(e); }
   }
 


### PR DESCRIPTION
## Summary
- allow computeFifo to initialize from historical positions and skip empty entries
- use InitialPosition mapping in dashboard and reload logic
- test FIFO with initial positions including partial closes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fce5d1b10832e8c7db6cf05165a45