### PR TITLE
fix: timestamp aware FIFO pnl

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m5-fifo-timestamp.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m5-fifo-timestamp.test.ts
@@ -1,0 +1,41 @@
+import { computeFifo } from "@/lib/fifo";
+import { calcMetrics } from "@/lib/metrics";
+import type { Trade, Position } from "@/lib/services/dataService";
+
+// Mock timezone to control today's date
+jest.mock("@/lib/timezone", () => {
+  const actual = jest.requireActual("@/lib/timezone");
+  return {
+    ...actual,
+    nowNY: () => new Date("2024-01-02T17:00:00-05:00"),
+  };
+});
+
+describe("M5 FIFO with timestamped trades", () => {
+  it("handles same-day trades with timestamps", () => {
+    const trades: Trade[] = [
+      {
+        symbol: "AAPL",
+        price: 100,
+        quantity: 10,
+        date: "2024-01-02T09:30:00-05:00",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 110,
+        quantity: 10,
+        date: "2024-01-02T14:30:00-05:00",
+        action: "sell",
+      },
+    ];
+
+    const enriched = computeFifo(trades);
+    const positions: Position[] = [];
+    const metrics = calcMetrics(enriched, positions);
+
+    // Both trades occur on the mocked "today" date, so FIFO profit should be recognized
+    expect(metrics.M5.fifo).toBe(100);
+    expect(metrics.M5.trade).toBe(100);
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -145,7 +145,11 @@ function calcTodayFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): nu
   const longFifo: Record<string, { qty: number; price: number; date: string }[]> = {};
   const shortFifo: Record<string, { qty: number; price: number; date: string }[]> = {};
   let pnl = 0;
-  const sorted = [...enrichedTrades].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  const sorted = [...enrichedTrades].sort(
+    (a, b) =>
+      (a.date ? new Date(a.date).getTime() : 0) -
+      (b.date ? new Date(b.date).getTime() : 0)
+  );
   for (const t of sorted) {
     const { symbol, action, price, date } = t;
     const quantity = Math.abs(t.quantity);


### PR DESCRIPTION
## Summary
- make FIFO PnL sorting and date comparisons tolerant of missing timestamps
- test FIFO PnL for trades with timestamped dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fd626de50832e9e359f2b8dcd6edc