### PR TITLE
refactor(metrics): compute daily pnl change from components

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m6-ignore-dailyResults.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m6-ignore-dailyResults.test.ts
@@ -1,0 +1,31 @@
+import { computeFifo } from "@/lib/fifo";
+import { calcMetrics, type DailyResult } from "@/lib/metrics";
+import type { Trade, Position } from "@/lib/services/dataService";
+
+jest.mock("@/lib/timezone", () => {
+  const actual = jest.requireActual("@/lib/timezone");
+  return {
+    ...actual,
+    nowNY: () => new Date("2024-01-02T00:00:00-05:00"),
+  };
+});
+
+describe("calcMetrics M6 ignores dailyResults pnl", () => {
+  it("computes M6 from components rather than dailyResults", () => {
+    const trades: Trade[] = [
+      { symbol: "AAPL", price: 100, quantity: 100, date: "2024-01-01", action: "buy" },
+      { symbol: "AAPL", price: 110, quantity: 100, date: "2024-01-02", action: "sell" },
+      { symbol: "AAPL", price: 100, quantity: 50, date: "2024-01-02", action: "buy" },
+      { symbol: "AAPL", price: 105, quantity: 50, date: "2024-01-02", action: "sell" },
+    ];
+
+    const enriched = computeFifo(trades);
+    const positions: Position[] = [];
+    const dailyResults: DailyResult[] = [
+      { date: "2024-01-02", realized: 0, float: 0, M5_1: 0, pnl: 9999 },
+    ];
+
+    const metrics = calcMetrics(enriched, positions, dailyResults);
+    expect(metrics.M6).toBe(1250);
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -458,11 +458,7 @@ export function calcMetrics(
   if (DEBUG) console.log('M4计算结果:', todayHistoricalRealizedPnl);
 
   // M6: 今日总盈利变化
-  // 优先使用 dailyResults 中当日记录的 pnl, 若不存在则按公式计算
-    const todayRecord = dailyResults.find(r => r.date?.startsWith(todayStr));
-  const todayTotalPnlChange = todayRecord
-    ? todayRecord.pnl
-    : todayHistoricalRealizedPnl + pnlFifo + floatPnl;
+  const todayTotalPnlChange = todayHistoricalRealizedPnl + pnlFifo + floatPnl;
   if (DEBUG) console.log('M6计算结果:', todayTotalPnlChange);
 
   // M7: 今日交易次数 (按 FIFO 拆分批次)


### PR DESCRIPTION
## Summary
- remove `todayRecord` shortcut in `calcMetrics` and always compute today's PnL change from historical realized, FIFO, and float values
- add regression test ensuring `dailyResults.pnl` no longer overrides computed M6

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fd75e9858832ea9b46934a587329a