### PR TITLE
Handle trades with invalid trade dates

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -7,6 +7,11 @@ trades must use negative `qty` values. For example, a short position of 80 share
 AMZN should appear as `"qty": -80`. This ensures short exposure is represented
 consistently across the application.
 
+Trades missing a valid `date` are treated as having occurred **after** all
+correctly timestamped trades. Their relative order is preserved, ensuring FIFO
+and metrics calculations remain deterministic even when some records have
+malformed or empty dates.
+
 ## Getting Started
 
 Copy the repository root `env.example` file to `.env` and fill in the required API keys before running the application.

--- a/apps/web/app/lib/__tests__/metrics-fifo-invalid-dates.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-fifo-invalid-dates.test.ts
@@ -1,0 +1,24 @@
+import { computeFifo } from "@/lib/fifo";
+import { calcMetrics } from "@/lib/metrics";
+import type { Trade } from "@/lib/services/dataService";
+
+describe("FIFO handling of invalid dates", () => {
+  it("orders malformed or missing dates last without throwing", () => {
+    const trades: Trade[] = [
+      { symbol: "U", price: 1, quantity: 1, date: undefined as any, action: "buy" },
+      { symbol: "E", price: 1, quantity: 1, date: "" as any, action: "buy" },
+      { symbol: "M", price: 1, quantity: 1, date: "bad-date", action: "buy" },
+      { symbol: "V1", price: 1, quantity: 1, date: "2024-01-01", action: "buy" },
+      { symbol: "V2", price: 1, quantity: 1, date: "2024-01-02", action: "buy" },
+    ];
+
+    let enriched;
+    expect(() => {
+      enriched = computeFifo(trades);
+      calcMetrics(enriched, []);
+    }).not.toThrow();
+
+    const order = enriched!.map((t) => t.symbol);
+    expect(order).toEqual(["V1", "V2", "U", "E", "M"]);
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -163,8 +163,8 @@ function calcTodayFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): nu
     .sort((a, b) => {
       const timeA = toNY(a.t.date).getTime();
       const timeB = toNY(b.t.date).getTime();
-      const aTime = isNaN(timeA) ? 0 : timeA;
-      const bTime = isNaN(timeB) ? 0 : timeB;
+      const aTime = isNaN(timeA) ? Infinity : timeA;
+      const bTime = isNaN(timeB) ? Infinity : timeB;
       return aTime - bTime || a.idx - b.idx;
     })
     .map(({ t }) => t);
@@ -233,8 +233,8 @@ function calcHistoryFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): 
     .sort((a, b) => {
       const timeA = toNY(a.t.date).getTime();
       const timeB = toNY(b.t.date).getTime();
-      const aTime = isNaN(timeA) ? 0 : timeA;
-      const bTime = isNaN(timeB) ? 0 : timeB;
+      const aTime = isNaN(timeA) ? Infinity : timeA;
+      const bTime = isNaN(timeB) ? Infinity : timeB;
       return aTime - bTime || a.idx - b.idx;
     })
     .map(({ t }) => t);
@@ -304,8 +304,8 @@ function calcWinLossLots(trades: EnrichedTrade[]): { wins: number; losses: numbe
     .sort((a, b) => {
       const timeA = toNY(a.t.date).getTime();
       const timeB = toNY(b.t.date).getTime();
-      const aTime = isNaN(timeA) ? 0 : timeA;
-      const bTime = isNaN(timeB) ? 0 : timeB;
+      const aTime = isNaN(timeA) ? Infinity : timeA;
+      const bTime = isNaN(timeB) ? Infinity : timeB;
       return aTime - bTime || a.idx - b.idx;
     })
     .map(({ t }) => t);
@@ -370,8 +370,8 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
     .sort((a, b) => {
       const timeA = toNY(a.t.date).getTime();
       const timeB = toNY(b.t.date).getTime();
-      const aTime = isNaN(timeA) ? 0 : timeA;
-      const bTime = isNaN(timeB) ? 0 : timeB;
+      const aTime = isNaN(timeA) ? Infinity : timeA;
+      const bTime = isNaN(timeB) ? Infinity : timeB;
       return aTime - bTime || a.idx - b.idx;
     })
     .map(({ t }) => t);


### PR DESCRIPTION
## Summary
- sort FIFO trades chronologically while pushing malformed or missing dates to the end
- ensure metrics sorters treat invalid dates as latest entries
- document invalid-date behavior and add regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689082557ce0832ea408af14699bd5be