### PR TITLE
Use timezone-aware checks in FIFO PnL

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m4-cross-midnight-utc.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m4-cross-midnight-utc.test.ts
@@ -1,0 +1,40 @@
+import { computeFifo } from "@/lib/fifo";
+import { calcMetrics } from "@/lib/metrics";
+import type { Trade, Position } from "@/lib/services/dataService";
+
+jest.mock("@/lib/timezone", () => {
+  const actual = jest.requireActual("@/lib/timezone");
+  return {
+    ...actual,
+    nowNY: () => new Date("2024-01-02T12:00:00-05:00"),
+  };
+});
+
+describe("historical PnL across UTC midnight", () => {
+  it("counts profit when trades span UTC midnight but same NY day", () => {
+    const trades: Trade[] = [
+      {
+        symbol: "AAPL",
+        price: 100,
+        quantity: 100,
+        date: "2024-01-02T01:00:00Z",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 110,
+        quantity: 100,
+        date: "2024-01-03T00:30:00Z",
+        action: "sell",
+      },
+    ];
+
+    const enriched = computeFifo(trades);
+    const positions: Position[] = [];
+    const metrics = calcMetrics(enriched, positions);
+
+    expect(metrics.M4).toBe(1000);
+    expect(metrics.M5.fifo).toBe(0);
+    expect(metrics.M5.trade).toBe(0);
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -250,7 +250,7 @@ function calcHistoryFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): 
       while (remain > 0 && fifo.length > 0) {
         const lot = fifo[0]!;
         const q = Math.min(lot.qty, remain);
-        if (date?.startsWith(todayStr) && !lot.date?.startsWith(todayStr)) {
+        if (isTodayNY(date, todayStr) && !isTodayNY(lot.date, todayStr)) {
           pnl += (price - lot.price) * q;
         }
         lot.qty -= q;
@@ -270,7 +270,7 @@ function calcHistoryFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): 
       while (remain > 0 && fifo.length > 0) {
         const lot = fifo[0]!;
         const q = Math.min(lot.qty, remain);
-        if (date?.startsWith(todayStr) && !lot.date?.startsWith(todayStr)) {
+        if (isTodayNY(date, todayStr) && !isTodayNY(lot.date, todayStr)) {
           pnl += (lot.price - price) * q;
         }
         lot.qty -= q;


### PR DESCRIPTION
## Summary
- rely on `isTodayNY` when determining if FIFO lots are closed today
- add test ensuring PnL from trades spanning UTC midnight are recognized on the same NY day

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689085e079f8832e833ba8b4ee860b7c