### PR TITLE
Refine today PnL sorting for NY timezone

### DIFF
--- a/apps/web/app/lib/__tests__/calcTodayTradePnL.test.ts
+++ b/apps/web/app/lib/__tests__/calcTodayTradePnL.test.ts
@@ -1,0 +1,25 @@
+import { calcTodayTradePnL } from "@/lib/calcTodayTradePnL";
+import type { EnrichedTrade } from "@/lib/fifo";
+
+describe("calcTodayTradePnL sorting", () => {
+  it("processes identical timestamps in original order", () => {
+    const trades: EnrichedTrade[] = [
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
+      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
+    ];
+    const pnl = calcTodayTradePnL(trades, "2024-08-20");
+    expect(pnl).toBe(0);
+  });
+
+  it("ignores malformed dates without throwing", () => {
+    const trades: EnrichedTrade[] = [
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "bad-date" } as any,
+      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T09:00:00Z" } as any,
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
+    ];
+    expect(() => calcTodayTradePnL(trades, "2024-08-20")).not.toThrow();
+    const pnl = calcTodayTradePnL(trades, "2024-08-20");
+    expect(pnl).toBe(10);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure calcTodayTradePnL filters with `isTodayNY` and sorts using a stable `toNY` comparator
- add tests for identical timestamps and malformed dates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689088053458832e9fdb5dff84848a6a