### PR TITLE
feat: enforce New York timezone

### DIFF
--- a/apps/web/app/lib/calcTodayTradePnL.ts
+++ b/apps/web/app/lib/calcTodayTradePnL.ts
@@ -1,4 +1,5 @@
 import type { EnrichedTrade } from "@/lib/fifo";
+import { toNY } from "@/lib/timezone";
 
 /**
  * 计算日内交易盈亏（交易视角）
@@ -18,7 +19,7 @@ export function calcTodayTradePnL(enrichedTrades: EnrichedTrade[], todayStr: str
   enrichedTrades
     // Some trade records may miss the date field; guard to prevent runtime errors
     .filter(t => t.date?.startsWith(todayStr))
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    .sort((a, b) => toNY(a.date).getTime() - toNY(b.date).getTime())
     .forEach(t => {
       const { symbol, action, price } = t;
       const quantity = Math.abs(t.quantity);

--- a/apps/web/app/lib/services/priceService.ts
+++ b/apps/web/app/lib/services/priceService.ts
@@ -1,6 +1,7 @@
 import { getPrice, putPrice, CachedPrice } from './dataService';
 // 所有外部 API 调用都通过 apiQueue 进行排队以防止触发速率限制
 import { apiQueue } from './apiQueue';
+import { toNY } from '../timezone';
 
 // 将收盘价写入服务器端 JSON 文件
 async function saveToFile(symbol: string, date: string, close: number) {
@@ -102,8 +103,8 @@ async function fetchFinnhubDailyClose(symbol: string, date: string): Promise<num
     return null;
   }
 
-  const fromTs = Math.floor(new Date(`${date}T00:00:00Z`).getTime() / 1000);
-  const toTs = Math.floor(new Date(`${date}T23:59:59Z`).getTime() / 1000);
+  const fromTs = Math.floor(toNY(`${date}T00:00:00`).getTime() / 1000);
+  const toTs = Math.floor(toNY(`${date}T23:59:59`).getTime() / 1000);
   // 通过内部 API 路由转发请求，避免在浏览器暴露密钥
   const url = `/api/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${fromTs}&to=${toTs}`;
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link';
 import { calcMetrics } from '@/lib/metrics';
 import { useStore } from '@/lib/store';
 import { fetchRealtimeQuote, fetchDailyClose } from '@/lib/services/priceService';
+import { nowNY } from '@/lib/timezone';
 
 async function computeDataHash(data: unknown): Promise<string> {
   const json = JSON.stringify(data);
@@ -102,7 +103,7 @@ export default function DashboardPage() {
           try {
             let result = await fetchRealtimeQuote(pos.symbol);
             if (!result || result.price === 1) {
-              const today = new Date().toISOString().slice(0, 10);
+              const today = nowNY().toISOString().slice(0, 10);
               result = await fetchDailyClose(pos.symbol, today);
             }
 
@@ -197,7 +198,7 @@ export default function DashboardPage() {
         try {
           let result = await fetchRealtimeQuote(pos.symbol);
           if (!result || result.price === 1) {
-            const today = new Date().toISOString().slice(0, 10);
+            const today = nowNY().toISOString().slice(0, 10);
             result = await fetchDailyClose(pos.symbol, today);
           }
           if (result && result.price && result.price !== 1) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack --port 3000",
-    "build": "next build",
-    "start": "next start",
+    "dev": "TZ=America/New_York next dev --turbopack --port 3000",
+    "build": "TZ=America/New_York next build",
+    "start": "TZ=America/New_York next start",
     "lint": "next lint --max-warnings 0",
     "check-types": "tsc --noEmit"
   },

--- a/apps/web/public/js/analysisPage.js
+++ b/apps/web/public/js/analysisPage.js
@@ -21,7 +21,7 @@
     let pos = {}; // symbol: {qty, cost}
     let prevUnreal = 0;
     let dateArr = [];
-    for(let d=new Date(minDate+'T00:00:00Z'); d<=new Date(maxDate+'T00:00:00Z'); d.setUTCDate(d.getUTCDate()+1)){
+    for(let d=toNY(`${minDate}T00:00:00`); d<=toNY(`${maxDate}T00:00:00`); d.setDate(d.getDate()+1)){
       dateArr.push(formatDate(d));
     }
     for(const date of dateArr){
@@ -65,7 +65,7 @@
       // 按周合并
       let weekMap={}, cum=0;
       arr.forEach(d=>{
-        let key = d.date.slice(0,7)+'-W'+new Date(d.date).getUTCDay();
+        let key = d.date.slice(0,7)+'-W'+toNY(d.date).getDay();
         weekMap[key]=(weekMap[key]||0)+d.net;
       });
       arr = Object.entries(weekMap).map(([k,v],i)=>({date:k, cumulative:(arr[i-1]?.cumulative||0)+v}));

--- a/apps/web/public/js/fifo.js
+++ b/apps/web/public/js/fifo.js
@@ -1,13 +1,12 @@
+const { toNY } = window;
 
-// ---- Helper: getWeekIdx returns 0 (Sun) - 6 (Sat) using UTC to avoid timezone skew ----
+// ---- Helper: getWeekIdx returns 0 (Sun) - 6 (Sat) in New York time ----
 function getWeekIdx(dateStr){
-  const parts = dateStr.split('-').map(Number);
-  return new Date(Date.UTC(parts[0], parts[1]-1, parts[2])).getUTCDay();
+  return toNY(dateStr).getDay();
 }
 
 /* FIFO cost calculation & metrics – ported from Apps Script (迭代3.3.2) */
 (function(g){
-  const { toNY } = window;
   function computeFIFO(allTrades){
     const EPS = 1e-6;
     const symMap = {};   // per‑symbol state

--- a/apps/web/public/js/historicalBackfill.js
+++ b/apps/web/public/js/historicalBackfill.js
@@ -7,6 +7,11 @@
  */
 import { fetchDailyCandles, saveDailyClosesBulk, getTrackedSymbols } from './services/priceService.js';
 
+// Lightweight timezone helpers (NY)
+const TZ = 'America/New_York';
+const toNY = (...args) => new Date(new Date(...args).toLocaleString('en-US', { timeZone: TZ }));
+const nowNY = () => toNY();
+
 const START_DATE = '2025-04-07';  // inclusive
 const DELAY_PER_CALL_MS = 1200;   // <= 50 requests per minute
 
@@ -16,8 +21,8 @@ export async function runHistoricalBackfill(progressCallback = () => {}) {
     console.warn('[Backfill] No tracked symbols found.');
     return;
   }
-  const startEpoch = Math.floor(new Date(START_DATE + 'T00:00:00Z').getTime() / 1000);
-  const endEpoch = Math.floor(Date.now() / 1000);
+  const startEpoch = Math.floor(toNY(`${START_DATE}T00:00:00`).getTime() / 1000);
+  const endEpoch = Math.floor(nowNY().getTime() / 1000);
 
   for (let i = 0; i < symbols.length; i++) {
     const sym = symbols[i];

--- a/apps/web/public/js/services/finnhubService.js
+++ b/apps/web/public/js/services/finnhubService.js
@@ -6,6 +6,9 @@
 import { apiQueue } from './apiQueue.js';
 import { putPrice, getPrice } from '../lib/idb.js';
 
+// lightweight timezone helper
+const { toNY } = window;
+
 // 使用内部 API 路由，避免在浏览器暴露密钥
 const API_BASE  = '/api';
 /**
@@ -15,8 +18,8 @@ const API_BASE  = '/api';
  * @returns {number|null}
  */
 export async function fetchFinnhubDailyClose(symbol, date){
-  const fromTs = Math.floor(new Date(date + 'T00:00:00Z').getTime()/1000);
-  const toTs   = Math.floor(new Date(date + 'T23:59:59Z').getTime()/1000);
+  const fromTs = Math.floor(toNY(`${date}T00:00:00`).getTime()/1000);
+  const toTs   = Math.floor(toNY(`${date}T23:59:59`).getTime()/1000);
   const url = `${API_BASE}/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${fromTs}&to=${toTs}`;
   try{
     const json = await apiQueue.enqueue(()=> fetch(url).then(r=>r.json()));

--- a/apps/web/public/js/trades.js
+++ b/apps/web/public/js/trades.js
@@ -1,8 +1,8 @@
+const { toNY } = window;
 
-// ---- Helper: getWeekIdx returns 0 (Sun) - 6 (Sat) using UTC to avoid timezone skew ----
+// ---- Helper: getWeekIdx returns 0 (Sun) - 6 (Sat) in New York time ----
 function getWeekIdx(dateStr){
-  const parts = dateStr.split('-').map(Number);
-  return new Date(Date.UTC(parts[0], parts[1]-1, parts[2])).getUTCDay();
+  return toNY(dateStr).getDay();
 }
 (function(){
 const tbl=document.getElementById('all-trades');
@@ -15,7 +15,6 @@ function getSideClass(side) {
 }
 function render(){
   let trades = JSON.parse(localStorage.getItem('trades')||'[]');
-  const { toNY } = window;
   trades.sort((a,b)=> toNY(b.date)-toNY(a.date));
   trades = window.FIFO ? window.FIFO.computeFIFO(trades) : trades;
 


### PR DESCRIPTION
## Summary
- ensure trades are sorted using `toNY` in daily PnL calculator
- generate Finnhub timestamps with NY-based helpers and default server TZ
- normalize all public scripts to New York timezone

## Testing
- `npm test`
- `npm run lint` *(fails: command /root/.nvm/versions/node/v20.19.4/bin/npm run lint exited with 1)*
- `npx eslint app/lib/calcTodayTradePnL.ts app/lib/services/priceService.ts app/page.tsx` *(warnings: 8 problems, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689089d90c10832e81a8c0ea53258fd2