### PR TITLE
fix: correct sell/cover trade counts

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m7.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m7.test.ts
@@ -1,0 +1,38 @@
+import { computeFifo } from "@/lib/fifo";
+import { calcMetrics } from "@/lib/metrics";
+import type { Trade } from "@/lib/services/dataService";
+
+jest.mock("@/lib/timezone", () => {
+  const actual = jest.requireActual("@/lib/timezone");
+  return {
+    ...actual,
+    nowNY: () => new Date("2024-01-02T00:00:00-05:00"),
+  };
+});
+
+describe("calcMetrics M7 counts", () => {
+  it("counts sell and cover once per trade", () => {
+    const trades: Trade[] = [
+      { symbol: "AAPL", price: 100, quantity: 100, date: "2024-01-02T10:00:00-05:00", action: "buy" },
+      { symbol: "AAPL", price: 110, quantity: 50, date: "2024-01-02T11:00:00-05:00", action: "buy" },
+      { symbol: "AAPL", price: 120, quantity: 150, date: "2024-01-02T12:00:00-05:00", action: "sell" },
+      { symbol: "MSFT", price: 200, quantity: 30, date: "2024-01-02T09:00:00-05:00", action: "short" },
+      { symbol: "MSFT", price: 210, quantity: 20, date: "2024-01-02T09:30:00-05:00", action: "short" },
+      { symbol: "MSFT", price: 190, quantity: 50, date: "2024-01-02T13:00:00-05:00", action: "cover" },
+    ];
+
+    const metrics = calcMetrics(computeFifo(trades), []);
+    expect(metrics.M7).toEqual({ B: 2, S: 1, P: 2, C: 1, total: 6 });
+  });
+
+  it("handles trades that both close and open positions", () => {
+    const trades: Trade[] = [
+      { symbol: "TSLA", price: 100, quantity: 10, date: "2024-01-02T10:00:00-05:00", action: "buy" },
+      { symbol: "TSLA", price: 90, quantity: 15, date: "2024-01-02T11:00:00-05:00", action: "sell" },
+      { symbol: "TSLA", price: 95, quantity: 10, date: "2024-01-02T12:00:00-05:00", action: "cover" },
+    ];
+
+    const metrics = calcMetrics(computeFifo(trades), []);
+    expect(metrics.M7).toEqual({ B: 2, S: 1, P: 1, C: 1, total: 5 });
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -387,14 +387,16 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
     } else if (action === 'sell') {
       let remain = quantity;
       const fifo = longFifo[symbol] || [];
+      let closed = false;
       while (remain > 0 && fifo.length > 0) {
         const lot = fifo[0]!;
         const q = Math.min(lot.qty, remain);
         lot.qty -= q;
         remain -= q;
-        if (isTodayNY(date, todayStr)) S++;
+        closed = true;
         if (lot.qty === 0) fifo.shift();
       }
+      if (isTodayNY(date, todayStr) && closed) S++;
       if (remain > 0) {
         if (!shortFifo[symbol]) shortFifo[symbol] = [];
         shortFifo[symbol].push({ qty: remain });
@@ -407,14 +409,16 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
     } else if (action === 'cover') {
       let remain = quantity;
       const fifo = shortFifo[symbol] || [];
+      let closed = false;
       while (remain > 0 && fifo.length > 0) {
         const lot = fifo[0]!;
         const q = Math.min(lot.qty, remain);
         lot.qty -= q;
         remain -= q;
-        if (isTodayNY(date, todayStr)) C++;
+        closed = true;
         if (lot.qty === 0) fifo.shift();
       }
+      if (isTodayNY(date, todayStr) && closed) C++;
       if (remain > 0) {
         if (!longFifo[symbol]) longFifo[symbol] = [];
         longFifo[symbol].push({ qty: remain });


### PR DESCRIPTION
## Summary
- avoid inflating sell/cover counts when closing multiple lots in `calcTodayTradeCounts`
- add tests for M7 trade counting, including mixed open/close scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68908fc72b44832eb0eefbec5324e869