### PR TITLE
feat: add trading day helper

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-historical.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-historical.test.ts
@@ -6,23 +6,53 @@ jest.mock("@/lib/timezone", () => {
   const actual = jest.requireActual("@/lib/timezone");
   return {
     ...actual,
-    nowNY: () => new Date("2024-01-02T00:00:00-05:00"),
+    nowNY: () => new Date("2024-01-02T10:00:00-05:00"),
   };
 });
 
 describe("calcMetrics with historical positions", () => {
   it("matches expected M1-M5 values", () => {
     const trades: Trade[] = [
-      { symbol: "AAPL", price: 100, quantity: 100, date: "2024-01-01", action: "buy" },
-      { symbol: "AAPL", price: 110, quantity: 50, date: "2024-01-02", action: "sell" },
-      { symbol: "AAPL", price: 105, quantity: 20, date: "2024-01-02", action: "buy" },
-      { symbol: "AAPL", price: 108, quantity: 20, date: "2024-01-02", action: "sell" },
+      {
+        symbol: "AAPL",
+        price: 100,
+        quantity: 100,
+        date: "2024-01-01",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 110,
+        quantity: 50,
+        date: "2024-01-02",
+        action: "sell",
+      },
+      {
+        symbol: "AAPL",
+        price: 105,
+        quantity: 20,
+        date: "2024-01-02",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 108,
+        quantity: 20,
+        date: "2024-01-02",
+        action: "sell",
+      },
     ];
 
     const enriched = computeFifo(trades);
     const last = enriched[enriched.length - 1]!;
     const positions: Position[] = [
-      { symbol: "AAPL", qty: last.quantityAfter, avgPrice: last.averageCost, last: 110, priceOk: true },
+      {
+        symbol: "AAPL",
+        qty: last.quantityAfter,
+        avgPrice: last.averageCost,
+        last: 110,
+        priceOk: true,
+      },
     ];
 
     const metrics = calcMetrics(enriched, positions);

--- a/apps/web/app/lib/__tests__/metrics-m6-ignore-dailyResults.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m6-ignore-dailyResults.test.ts
@@ -6,17 +6,41 @@ jest.mock("@/lib/timezone", () => {
   const actual = jest.requireActual("@/lib/timezone");
   return {
     ...actual,
-    nowNY: () => new Date("2024-01-02T00:00:00-05:00"),
+    nowNY: () => new Date("2024-01-02T10:00:00-05:00"),
   };
 });
 
 describe("calcMetrics M6 ignores dailyResults pnl", () => {
   it("computes M6 from components rather than dailyResults", () => {
     const trades: Trade[] = [
-      { symbol: "AAPL", price: 100, quantity: 100, date: "2024-01-01", action: "buy" },
-      { symbol: "AAPL", price: 110, quantity: 100, date: "2024-01-02", action: "sell" },
-      { symbol: "AAPL", price: 100, quantity: 50, date: "2024-01-02", action: "buy" },
-      { symbol: "AAPL", price: 105, quantity: 50, date: "2024-01-02", action: "sell" },
+      {
+        symbol: "AAPL",
+        price: 100,
+        quantity: 100,
+        date: "2024-01-01",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 110,
+        quantity: 100,
+        date: "2024-01-02",
+        action: "sell",
+      },
+      {
+        symbol: "AAPL",
+        price: 100,
+        quantity: 50,
+        date: "2024-01-02",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 105,
+        quantity: 50,
+        date: "2024-01-02",
+        action: "sell",
+      },
     ];
 
     const enriched = computeFifo(trades);

--- a/apps/web/app/lib/__tests__/metrics-m7.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m7.test.ts
@@ -6,19 +6,55 @@ jest.mock("@/lib/timezone", () => {
   const actual = jest.requireActual("@/lib/timezone");
   return {
     ...actual,
-    nowNY: () => new Date("2024-01-02T00:00:00-05:00"),
+    nowNY: () => new Date("2024-01-02T10:00:00-05:00"),
   };
 });
 
 describe("calcMetrics M7 counts", () => {
   it("counts sell and cover once per trade", () => {
     const trades: Trade[] = [
-      { symbol: "AAPL", price: 100, quantity: 100, date: "2024-01-02T10:00:00-05:00", action: "buy" },
-      { symbol: "AAPL", price: 110, quantity: 50, date: "2024-01-02T11:00:00-05:00", action: "buy" },
-      { symbol: "AAPL", price: 120, quantity: 150, date: "2024-01-02T12:00:00-05:00", action: "sell" },
-      { symbol: "MSFT", price: 200, quantity: 30, date: "2024-01-02T09:00:00-05:00", action: "short" },
-      { symbol: "MSFT", price: 210, quantity: 20, date: "2024-01-02T09:30:00-05:00", action: "short" },
-      { symbol: "MSFT", price: 190, quantity: 50, date: "2024-01-02T13:00:00-05:00", action: "cover" },
+      {
+        symbol: "AAPL",
+        price: 100,
+        quantity: 100,
+        date: "2024-01-02T10:00:00-05:00",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 110,
+        quantity: 50,
+        date: "2024-01-02T11:00:00-05:00",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 120,
+        quantity: 150,
+        date: "2024-01-02T12:00:00-05:00",
+        action: "sell",
+      },
+      {
+        symbol: "MSFT",
+        price: 200,
+        quantity: 30,
+        date: "2024-01-02T09:00:00-05:00",
+        action: "short",
+      },
+      {
+        symbol: "MSFT",
+        price: 210,
+        quantity: 20,
+        date: "2024-01-02T09:30:00-05:00",
+        action: "short",
+      },
+      {
+        symbol: "MSFT",
+        price: 190,
+        quantity: 50,
+        date: "2024-01-02T13:00:00-05:00",
+        action: "cover",
+      },
     ];
 
     const metrics = calcMetrics(computeFifo(trades), []);
@@ -27,9 +63,27 @@ describe("calcMetrics M7 counts", () => {
 
   it("handles trades that both close and open positions", () => {
     const trades: Trade[] = [
-      { symbol: "TSLA", price: 100, quantity: 10, date: "2024-01-02T10:00:00-05:00", action: "buy" },
-      { symbol: "TSLA", price: 90, quantity: 15, date: "2024-01-02T11:00:00-05:00", action: "sell" },
-      { symbol: "TSLA", price: 95, quantity: 10, date: "2024-01-02T12:00:00-05:00", action: "cover" },
+      {
+        symbol: "TSLA",
+        price: 100,
+        quantity: 10,
+        date: "2024-01-02T10:00:00-05:00",
+        action: "buy",
+      },
+      {
+        symbol: "TSLA",
+        price: 90,
+        quantity: 15,
+        date: "2024-01-02T11:00:00-05:00",
+        action: "sell",
+      },
+      {
+        symbol: "TSLA",
+        price: 95,
+        quantity: 10,
+        date: "2024-01-02T12:00:00-05:00",
+        action: "cover",
+      },
     ];
 
     const metrics = calcMetrics(computeFifo(trades), []);

--- a/apps/web/app/lib/__tests__/timezone.test.ts
+++ b/apps/web/app/lib/__tests__/timezone.test.ts
@@ -1,0 +1,15 @@
+import { getLatestTradingDayStr } from "../timezone";
+
+describe("getLatestTradingDayStr", () => {
+  it("returns previous Friday before market open on Monday", () => {
+    expect(getLatestTradingDayStr(new Date("2024-05-06T08:00:00-04:00"))).toBe(
+      "2024-05-03",
+    );
+  });
+
+  it("returns same day during market hours", () => {
+    expect(getLatestTradingDayStr(new Date("2024-05-06T10:00:00-04:00"))).toBe(
+      "2024-05-06",
+    );
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -1,10 +1,10 @@
 import type { EnrichedTrade } from "@/lib/fifo";
-import type { Position } from '@/lib/services/dataService';
-import { nowNY, toNY } from '@/lib/timezone';
-import { calcTodayTradePnL } from './calcTodayTradePnL';
+import type { Position } from "@/lib/services/dataService";
+import { nowNY, toNY, getLatestTradingDayStr } from "@/lib/timezone";
+import { calcTodayTradePnL } from "./calcTodayTradePnL";
 
 // Only enable verbose logging outside production
-const DEBUG = process.env.NODE_ENV !== 'production';
+const DEBUG = process.env.NODE_ENV !== "production";
 
 /**
  * 交易系统指标接口
@@ -23,7 +23,7 @@ export interface Metrics {
   /** M4: 今天持仓平仓盈利 - 今日平掉历史仓位的盈亏 */
   M4: number;
 
-  /** 
+  /**
    * M5: 今日日内交易盈利 - 同一天内开仓并平仓的交易盈亏
    * trade: 交易视角，按交易匹配计算
    * fifo: FIFO视角，按先进先出原则计算
@@ -71,7 +71,7 @@ export interface Metrics {
   /** M9: 所有历史平仓盈利 - 所有已实现盈亏的累计和 */
   M9: number;
 
-  /** 
+  /**
    * M10: 胜率统计
    * W: 盈利交易次数
    * L: 亏损交易次数
@@ -141,7 +141,7 @@ function isTodayNY(dateStr: string | undefined, todayStr: string): boolean {
 /**
  * 计算日内交易盈亏（交易视角）
  * 按照交易匹配的方式，计算同一天内开仓并平仓的交易盈亏
- * 
+ *
  * @param enrichedTrades 交易记录数组
  * @param todayStr 今日日期字符串，格式为 YYYY-MM-DD
  * @returns 日内交易盈亏
@@ -154,9 +154,18 @@ function isTodayNY(dateStr: string | undefined, todayStr: string): boolean {
  * @param todayStr 今日日期字符串，格式为 YYYY-MM-DD
  * @returns 日内交易盈亏
  */
-function calcTodayFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): number {
-  const longFifo: Record<string, { qty: number; price: number; date: string }[]> = {};
-  const shortFifo: Record<string, { qty: number; price: number; date: string }[]> = {};
+function calcTodayFifoPnL(
+  enrichedTrades: EnrichedTrade[],
+  todayStr: string,
+): number {
+  const longFifo: Record<
+    string,
+    { qty: number; price: number; date: string }[]
+  > = {};
+  const shortFifo: Record<
+    string,
+    { qty: number; price: number; date: string }[]
+  > = {};
   let pnl = 0;
   const sorted = enrichedTrades
     .map((t, idx) => ({ t, idx }))
@@ -171,10 +180,10 @@ function calcTodayFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): nu
   for (const t of sorted) {
     const { symbol, action, price, date } = t;
     const quantity = Math.abs(t.quantity);
-    if (action === 'buy') {
+    if (action === "buy") {
       if (!longFifo[symbol]) longFifo[symbol] = [];
       longFifo[symbol].push({ qty: quantity, price, date });
-    } else if (action === 'sell') {
+    } else if (action === "sell") {
       let remain = quantity;
       const fifo = longFifo[symbol] || [];
       while (remain > 0 && fifo.length > 0) {
@@ -191,10 +200,10 @@ function calcTodayFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): nu
         if (!shortFifo[symbol]) shortFifo[symbol] = [];
         shortFifo[symbol].push({ qty: remain, price, date });
       }
-    } else if (action === 'short') {
+    } else if (action === "short") {
       if (!shortFifo[symbol]) shortFifo[symbol] = [];
       shortFifo[symbol].push({ qty: quantity, price, date });
-    } else if (action === 'cover') {
+    } else if (action === "cover") {
       let remain = quantity;
       const fifo = shortFifo[symbol] || [];
       while (remain > 0 && fifo.length > 0) {
@@ -219,14 +228,23 @@ function calcTodayFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): nu
 /**
  * 计算历史交易盈亏（FIFO视角）
  * 按照先进先出原则，计算同一天内开仓并平仓的交易盈亏
- * 
+ *
  * @param enrichedTrades 交易记录数组
  * @param todayStr 今日日期字符串，格式为 YYYY-MM-DD
  * @returns 日内交易盈亏
  */
-function calcHistoryFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): number {
-  const longFifo: Record<string, { qty: number; price: number; date: string }[]> = {};
-  const shortFifo: Record<string, { qty: number; price: number; date: string }[]> = {};
+function calcHistoryFifoPnL(
+  enrichedTrades: EnrichedTrade[],
+  todayStr: string,
+): number {
+  const longFifo: Record<
+    string,
+    { qty: number; price: number; date: string }[]
+  > = {};
+  const shortFifo: Record<
+    string,
+    { qty: number; price: number; date: string }[]
+  > = {};
   let pnl = 0;
   const sorted = enrichedTrades
     .map((t, idx) => ({ t, idx }))
@@ -292,7 +310,10 @@ function calcHistoryFifoPnL(enrichedTrades: EnrichedTrade[], todayStr: string): 
  * @param trades 交易记录数组
  * @returns 包含 wins 与 losses 计数
  */
-function calcWinLossLots(trades: EnrichedTrade[]): { wins: number; losses: number } {
+function calcWinLossLots(trades: EnrichedTrade[]): {
+  wins: number;
+  losses: number;
+} {
   const longFifo: Record<string, { qty: number; price: number }[]> = {};
   const shortFifo: Record<string, { qty: number; price: number }[]> = {};
 
@@ -314,32 +335,34 @@ function calcWinLossLots(trades: EnrichedTrade[]): { wins: number; losses: numbe
     const { symbol, action, price } = t;
     const quantity = Math.abs(t.quantity);
 
-    if (action === 'buy') {
+    if (action === "buy") {
       if (!longFifo[symbol]) longFifo[symbol] = [];
       longFifo[symbol].push({ qty: quantity, price });
-    } else if (action === 'sell') {
+    } else if (action === "sell") {
       let remain = quantity;
       const fifo = longFifo[symbol] || [];
       while (remain > 0 && fifo.length > 0) {
         const lot = fifo[0]!;
         const q = Math.min(lot.qty, remain);
         const pnl = (price - lot.price) * q;
-        if (pnl > 0) wins++; else if (pnl < 0) losses++;
+        if (pnl > 0) wins++;
+        else if (pnl < 0) losses++;
         lot.qty -= q;
         remain -= q;
         if (lot.qty === 0) fifo.shift();
       }
-    } else if (action === 'short') {
+    } else if (action === "short") {
       if (!shortFifo[symbol]) shortFifo[symbol] = [];
       shortFifo[symbol].push({ qty: quantity, price });
-    } else if (action === 'cover') {
+    } else if (action === "cover") {
       let remain = quantity;
       const fifo = shortFifo[symbol] || [];
       while (remain > 0 && fifo.length > 0) {
         const lot = fifo[0]!;
         const q = Math.min(lot.qty, remain);
         const pnl = (lot.price - price) * q;
-        if (pnl > 0) wins++; else if (pnl < 0) losses++;
+        if (pnl > 0) wins++;
+        else if (pnl < 0) losses++;
         lot.qty -= q;
         remain -= q;
         if (lot.qty === 0) fifo.shift();
@@ -380,11 +403,11 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
     const { symbol, action, date } = t;
     const quantity = Math.abs(t.quantity);
 
-    if (action === 'buy') {
+    if (action === "buy") {
       if (!longFifo[symbol]) longFifo[symbol] = [];
       longFifo[symbol].push({ qty: quantity });
       if (isTodayNY(date, todayStr)) B++;
-    } else if (action === 'sell') {
+    } else if (action === "sell") {
       let remain = quantity;
       const fifo = longFifo[symbol] || [];
       let closed = false;
@@ -402,11 +425,11 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
         shortFifo[symbol].push({ qty: remain });
         if (isTodayNY(date, todayStr)) P++;
       }
-    } else if (action === 'short') {
+    } else if (action === "short") {
       if (!shortFifo[symbol]) shortFifo[symbol] = [];
       shortFifo[symbol].push({ qty: quantity });
       if (isTodayNY(date, todayStr)) P++;
-    } else if (action === 'cover') {
+    } else if (action === "cover") {
       let remain = quantity;
       const fifo = shortFifo[symbol] || [];
       let closed = false;
@@ -432,17 +455,17 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
 
 /**
  * 计算周期性指标（WTD、MTD、YTD）
- * 
+ *
  * @param dailyResults 每日交易结果数组
  * @param todayStr 今日日期字符串，格式为 YYYY-MM-DD
  * @returns 包含 wtd、mtd、ytd 的对象
  */
 function calcPeriodMetrics(
   dailyResults: DailyResult[],
-  todayStr: string
+  todayStr: string,
 ): { wtd: number; mtd: number; ytd: number } {
   const sumSince = (since: string) =>
-    dailyResults.filter(r => r.date >= since).reduce((a, r) => a + r.pnl, 0);
+    dailyResults.filter((r) => r.date >= since).reduce((a, r) => a + r.pnl, 0);
 
   // Ensure calculations are based on New York time
   const today = toNY(`${todayStr}T00:00:00`);
@@ -453,14 +476,14 @@ function calcPeriodMetrics(
 
   return {
     wtd: sumSince(mondayStr),
-    mtd: sumSince(todayStr.slice(0, 8) + '01'),
-    ytd: sumSince(todayStr.slice(0, 4) + '-01-01'),
+    mtd: sumSince(todayStr.slice(0, 8) + "01"),
+    ytd: sumSince(todayStr.slice(0, 4) + "-01-01"),
   };
 }
 
 /**
  * 计算所有交易指标
- * 
+ *
  * @param trades 交易记录数组
  * @param positions 持仓数组
  * @param dailyResults 每日交易结果数组
@@ -469,22 +492,29 @@ function calcPeriodMetrics(
 export function calcMetrics(
   trades: EnrichedTrade[],
   positions: Position[],
-  dailyResults: DailyResult[] = []
+  dailyResults: DailyResult[] = [],
 ): Metrics {
   // 获取今日日期字符串（纽约时区）
-  const todayStr = nowNY().toISOString().slice(0, 10);
+  const todayStr = getLatestTradingDayStr(nowNY());
 
   // M1: 持仓成本
-  const totalCost = sum(positions.map(p => Math.abs(p.avgPrice * p.qty)));
+  const totalCost = sum(positions.map((p) => Math.abs(p.avgPrice * p.qty)));
 
   // M2: 持仓市值
-  if (DEBUG) console.log('计算M2(持仓市值)，持仓数据:', positions);
-  const currentValue = sum(positions.map(p => {
-    const marketValue = p.last * Math.abs(p.qty);
-    if (DEBUG) console.log(`${p.symbol} 市值计算:`, { last: p.last, qty: p.qty, marketValue });
-    return marketValue;
-  }));
-  if (DEBUG) console.log('M2(持仓市值)计算结果:', currentValue);
+  if (DEBUG) console.log("计算M2(持仓市值)，持仓数据:", positions);
+  const currentValue = sum(
+    positions.map((p) => {
+      const marketValue = p.last * Math.abs(p.qty);
+      if (DEBUG)
+        console.log(`${p.symbol} 市值计算:`, {
+          last: p.last,
+          qty: p.qty,
+          marketValue,
+        });
+      return marketValue;
+    }),
+  );
+  if (DEBUG) console.log("M2(持仓市值)计算结果:", currentValue);
 
   // M3: 持仓浮盈
   const floatPnl = positions.reduce((acc, pos) => {
@@ -505,11 +535,11 @@ export function calcMetrics(
   // M4: 今天持仓平仓盈利（仅历史仓位，不含日内交易）
   // 日内交易的 FIFO 盈亏已包含在 pnlFifo，需要剔除
   const todayHistoricalRealizedPnl = calcHistoryFifoPnL(trades, todayStr);
-  if (DEBUG) console.log('M4计算结果:', todayHistoricalRealizedPnl);
+  if (DEBUG) console.log("M4计算结果:", todayHistoricalRealizedPnl);
 
   // M6: 今日总盈利变化
   const todayTotalPnlChange = todayHistoricalRealizedPnl + pnlFifo + floatPnl;
-  if (DEBUG) console.log('M6计算结果:', todayTotalPnlChange);
+  if (DEBUG) console.log("M6计算结果:", todayTotalPnlChange);
 
   // M7: 今日交易次数 (按 FIFO 拆分批次)
   const todayTradeCountsByType = calcTodayTradeCounts(trades, todayStr);
@@ -521,24 +551,29 @@ export function calcMetrics(
 
   // M8: 累计交易次数
   const allTradesByType = {
-    B: trades.filter(t => t.action === 'buy').length,
-    S: trades.filter(t => t.action === 'sell').length,
-    P: trades.filter(t => t.action === 'short').length,
-    C: trades.filter(t => t.action === 'cover').length
+    B: trades.filter((t) => t.action === "buy").length,
+    S: trades.filter((t) => t.action === "sell").length,
+    P: trades.filter((t) => t.action === "short").length,
+    C: trades.filter((t) => t.action === "cover").length,
   };
-  const totalTrades = allTradesByType.B + allTradesByType.S + allTradesByType.P + allTradesByType.C;
+  const totalTrades =
+    allTradesByType.B +
+    allTradesByType.S +
+    allTradesByType.P +
+    allTradesByType.C;
 
   // M9: 所有历史平仓盈利（含今日）
   const historicalRealizedPnl = dailyResults.length
     ? dailyResults.reduce((acc, r) => acc + r.realized, 0)
     : trades.reduce((acc, t) => acc + (t.realizedPnl || 0), 0);
-  if (DEBUG) console.log('M9计算结果:', historicalRealizedPnl);
+  if (DEBUG) console.log("M9计算结果:", historicalRealizedPnl);
 
   // M10: 胜率
   const { wins: winningTrades, losses: losingTrades } = calcWinLossLots(trades);
-  const winRate = winningTrades + losingTrades > 0
-    ? (winningTrades / (winningTrades + losingTrades)) * 100
-    : 0;
+  const winRate =
+    winningTrades + losingTrades > 0
+      ? (winningTrades / (winningTrades + losingTrades)) * 100
+      : 0;
 
   // M11-13: 周期性指标
   const { wtd, mtd, ytd } = calcPeriodMetrics(dailyResults, todayStr);
@@ -550,7 +585,7 @@ export function calcMetrics(
     M4: todayHistoricalRealizedPnl,
     M5: {
       trade: pnlTrade,
-      fifo: pnlFifo
+      fifo: pnlFifo,
     },
     M6: todayTotalPnlChange,
     M7: {
@@ -558,24 +593,24 @@ export function calcMetrics(
       S: todayTradeCountsByType.S,
       P: todayTradeCountsByType.P,
       C: todayTradeCountsByType.C,
-      total: todayTradeCounts
+      total: todayTradeCounts,
     },
     M8: {
       B: allTradesByType.B,
       S: allTradesByType.S,
       P: allTradesByType.P,
       C: allTradesByType.C,
-      total: totalTrades
+      total: totalTrades,
     },
     M9: historicalRealizedPnl,
     M10: {
       W: winningTrades,
       L: losingTrades,
-      rate: winRate
+      rate: winRate,
     },
     M11: wtd,
     M12: mtd,
-    M13: ytd
+    M13: ytd,
   };
 }
 
@@ -589,7 +624,7 @@ export function formatCurrency(value: number): string {
     style: "currency",
     currency: "USD",
     minimumFractionDigits: 2,
-    maximumFractionDigits: 2
+    maximumFractionDigits: 2,
   }).format(value);
 }
 
@@ -600,6 +635,6 @@ export function formatCurrency(value: number): string {
  * @returns 格式化后的字符串
  */
 export function formatNumber(value: number, decimals: number = 2): string {
-  if (isNaN(value)) return 'N/A';
+  if (isNaN(value)) return "N/A";
   return value.toFixed(decimals);
-} 
+}

--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -14,8 +14,8 @@
  */
 
 // Ensure server timezone defaults to New York
-if (typeof process !== 'undefined') {
-  process.env.TZ = process.env.TZ || 'America/New_York';
+if (typeof process !== "undefined") {
+  process.env.TZ = process.env.TZ || "America/New_York";
 }
 export function toNY(): Date;
 export function toNY(value: string | number | Date): Date;
@@ -46,7 +46,9 @@ export function toNY(...args: any[]): Date {
   }
 
   // 若环境时区已经是纽约，则无需转换
-  const localeString = date.toLocaleString('en-US', { timeZone: 'America/New_York' });
+  const localeString = date.toLocaleString("en-US", {
+    timeZone: "America/New_York",
+  });
   return new Date(localeString);
 }
 
@@ -57,19 +59,40 @@ export const nowNY = (): Date => toNY();
 export const formatNY = (
   dateInput: string | number | Date,
   options: Intl.DateTimeFormatOptions = {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
   },
 ): string =>
-  new Intl.DateTimeFormat('en-US', { timeZone: 'America/New_York', ...options }).format(
-    typeof dateInput === 'object' ? (dateInput as Date) : toNY(dateInput),
+  new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    ...options,
+  }).format(
+    typeof dateInput === "object" ? (dateInput as Date) : toNY(dateInput),
   );
+
+/**
+ * 获取最新交易日（纽约时区）的日期字符串。
+ * 如果当前时间早于 09:30，则回退一天；
+ * 若结果落在周末，则继续回退直到周五。
+ * 返回格式为 YYYY-MM-DD。
+ */
+export const getLatestTradingDayStr = (base: Date = nowNY()): string => {
+  const d = toNY(base);
+  if (d.getHours() < 9 || (d.getHours() === 9 && d.getMinutes() < 30)) {
+    d.setDate(d.getDate() - 1);
+  }
+  while (d.getDay() === 0 || d.getDay() === 6) {
+    d.setDate(d.getDate() - 1);
+  }
+  return d.toISOString().slice(0, 10);
+};
 
 // Attach helper to global for quick usage in dev tools
 // @ts-ignore
 (globalThis as any).toNY = toNY;
 (globalThis as any).nowNY = nowNY;
 (globalThis as any).formatNY = formatNY;
+(globalThis as any).getLatestTradingDayStr = getLatestTradingDayStr;

--- a/apps/web/public/js/analysis.js
+++ b/apps/web/public/js/analysis.js
@@ -1,80 +1,88 @@
 /* Trading777 交易分析 – v7.7.3 */
-(function(){
-  const { nowNY, toNY } = window;
+(function () {
+  const { nowNY, toNY, getLatestTradingDayStr } = window;
   /* ---------- utilities ---------- */
-  function numberColor(v){
-    if(v>0) return 'green';
-    if(v<0) return 'red';
-    return 'white';
-  };  // ← 加上分号
-  function formatPnL(v){ return (isFinite(v)? v.toFixed(2):''); };  // ← 加上分号
+  function numberColor(v) {
+    if (v > 0) return "green";
+    if (v < 0) return "red";
+    return "white";
+  } // ← 加上分号
+  function formatPnL(v) {
+    return isFinite(v) ? v.toFixed(2) : "";
+  } // ← 加上分号
 
   /* ---------- clock ---------- */
-  function renderClocks(){
-    const fmt = tz => nowNY().toLocaleTimeString('en-GB',{timeZone:tz,hour12:false});
-    document.getElementById('clocks').innerHTML =
-      `纽约：${fmt('America/New_York')} | 瓦伦西亚：${fmt('Europe/Madrid')} | 上海：${fmt('Asia/Shanghai')}`;
-  };  // ← 加上分号
+  function renderClocks() {
+    const fmt = (tz) =>
+      nowNY().toLocaleTimeString("en-GB", { timeZone: tz, hour12: false });
+    document.getElementById("clocks").innerHTML =
+      `纽约：${fmt("America/New_York")} | 瓦伦西亚：${fmt("Europe/Madrid")} | 上海：${fmt("Asia/Shanghai")}`;
+  } // ← 加上分号
   renderClocks();
-  setInterval(renderClocks,1000*30);
+  setInterval(renderClocks, 1000 * 30);
 
   /* ---------- load trades ---------- */
-  let trades = JSON.parse(localStorage.getItem('trades')||'[]');
-  trades.forEach(t=>{ t.date = t.date||t.time||t.datetime; });
-  trades = trades.filter(t=>t.date && isFinite(t.pl));
+  let trades = JSON.parse(localStorage.getItem("trades") || "[]");
+  trades.forEach((t) => {
+    t.date = t.date || t.time || t.datetime;
+  });
+  trades = trades.filter((t) => t.date && isFinite(t.pl));
 
   /* ---------- build daily pnl map ---------- */
   const dailyMap = {};
-  trades.forEach(t=>{
-    const d = t.date.slice(0,10);
-    const pl = Number(t.pl)||0;
-    dailyMap[d] = (dailyMap[d]||0) + pl;
+  trades.forEach((t) => {
+    const d = t.date.slice(0, 10);
+    const pl = Number(t.pl) || 0;
+    dailyMap[d] = (dailyMap[d] || 0) + pl;
   });
   const allDates = Object.keys(dailyMap).sort();
 
   /* ---------- line chart (cumulative) ---------- */
-  let cum = 0, lineData = [], lastDate = '';
-  allDates.forEach(d=>{
+  let cum = 0,
+    lineData = [],
+    lastDate = "";
+  allDates.forEach((d) => {
     const v = dailyMap[d];
     cum += v;
     lineData.push([d, cum.toFixed(2)]);
     lastDate = d;
   });
-  const lineChart = echarts.init(document.getElementById('profit-line'));
+  const lineChart = echarts.init(document.getElementById("profit-line"));
   lineChart.setOption({
-    tooltip: { trigger: 'axis' },
-    xAxis: { type: 'category', data: lineData.map(i=>i[0]) },
-    yAxis: { type: 'value' },
-    series: [{ type: 'line', smooth: true, data: lineData.map(i=>i[1]) }]
+    tooltip: { trigger: "axis" },
+    xAxis: { type: "category", data: lineData.map((i) => i[0]) },
+    yAxis: { type: "value" },
+    series: [{ type: "line", smooth: true, data: lineData.map((i) => i[1]) }],
   });
 
   /* ---------- calendar ---------- */
-  const calendarWrap = document.getElementById('calendar-wrap');
+  const calendarWrap = document.getElementById("calendar-wrap");
   let curYearMonth = lastDate
-    ? lastDate.slice(0,7)
-    : nowNY().toISOString().slice(0,7);
+    ? lastDate.slice(0, 7)
+    : nowNY().toISOString().slice(0, 7);
 
-  function renderCalendar(ym){
-    const [y,m] = ym.split('-').map(n=>parseInt(n,10));
-    const first = toNY(y, m-1, 1);
+  function renderCalendar(ym) {
+    const [y, m] = ym.split("-").map((n) => parseInt(n, 10));
+    const first = toNY(y, m - 1, 1);
     const last = toNY(y, m, 0);
-    const startDow = (first.getDay()+6)%7; // Monday=0
-    const weeks = Math.ceil((startDow + last.getDate())/7);
+    const startDow = (first.getDay() + 6) % 7; // Monday=0
+    const weeks = Math.ceil((startDow + last.getDate()) / 7);
 
     let html = '<table class="calendar"><thead><tr>';
-    ['一','二','三','四','五','六','日'].forEach(d=>{ html += `<th>${d}</th>`; });
-    html += '</tr></thead><tbody>';
+    ["一", "二", "三", "四", "五", "六", "日"].forEach((d) => {
+      html += `<th>${d}</th>`;
+    });
+    html += "</tr></thead><tbody>";
 
     let day = 1;
-    for(let w=0; w<weeks; w++){
-      html += '<tr>';
-      for(let dow=0; dow<7; dow++){
-        const idx = w*7 + dow;
-        const dateStr = day <= last.getDate()
-          ? `${ym}-${String(day).padStart(2,'0')}`
-          : '';
-        if(idx < startDow || day > last.getDate()){
-          html += '<td></td>';
+    for (let w = 0; w < weeks; w++) {
+      html += "<tr>";
+      for (let dow = 0; dow < 7; dow++) {
+        const idx = w * 7 + dow;
+        const dateStr =
+          day <= last.getDate() ? `${ym}-${String(day).padStart(2, "0")}` : "";
+        if (idx < startDow || day > last.getDate()) {
+          html += "<td></td>";
         } else {
           const pnl = dailyMap[dateStr] || 0;
           const cls = numberColor(pnl);
@@ -82,173 +90,187 @@
           day++;
         }
       }
-      html += '</tr>';
+      html += "</tr>";
     }
-    html += '</tbody></table>';
+    html += "</tbody></table>";
 
     calendarWrap.innerHTML = html;
-    document.getElementById('cur-month').textContent = ym;
-  };  // ← 加上分号
+    document.getElementById("cur-month").textContent = ym;
+  } // ← 加上分号
   renderCalendar(curYearMonth);
 
-  document.getElementById('prev-month').onclick = ()=>{
-    const [y,m] = curYearMonth.split('-').map(Number);
-    const date = toNY(y, m-2, 1);
-    curYearMonth = `${date.getFullYear()}-${String(date.getMonth()+1).padStart(2,'0')}`;
+  document.getElementById("prev-month").onclick = () => {
+    const [y, m] = curYearMonth.split("-").map(Number);
+    const date = toNY(y, m - 2, 1);
+    curYearMonth = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
     renderCalendar(curYearMonth);
   };
-  document.getElementById('next-month').onclick = ()=>{
-    const [y,m] = curYearMonth.split('-').map(Number);
+  document.getElementById("next-month").onclick = () => {
+    const [y, m] = curYearMonth.split("-").map(Number);
     const date = toNY(y, m, 1);
-    curYearMonth = `${date.getFullYear()}-${String(date.getMonth()+1).padStart(2,'0')}`;
+    curYearMonth = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
     renderCalendar(curYearMonth);
   };
 
   /* ---------- leaderboard ---------- */
   const symMap = {};
-  trades.forEach(t=>{
-    symMap[t.symbol] = (symMap[t.symbol]||0) + Number(t.pl||0);
+  trades.forEach((t) => {
+    symMap[t.symbol] = (symMap[t.symbol] || 0) + Number(t.pl || 0);
   });
-  function sortAndSlice(arr, desc){
-    return arr.sort((a,b)=> desc ? b[1]-a[1] : a[1]-b[1]).slice(0,10);
-  };  // ← 加上分号
+  function sortAndSlice(arr, desc) {
+    return arr.sort((a, b) => (desc ? b[1] - a[1] : a[1] - b[1])).slice(0, 10);
+  } // ← 加上分号
 
   const profitList = sortAndSlice(
-    Object.entries(symMap).filter(([s,v])=>v>0),
-    true
+    Object.entries(symMap).filter(([s, v]) => v > 0),
+    true,
   );
   const lossList = sortAndSlice(
-    Object.entries(symMap).filter(([s,v])=>v<0),
-    false
+    Object.entries(symMap).filter(([s, v]) => v < 0),
+    false,
   );
 
-  const tbl = document.getElementById('leaderboard');
-  function renderBoard(list){
-    tbl.innerHTML = '<tr><th>#</th><th>代码</th><th>中文</th><th>累计盈亏</th></tr>';
-    list.forEach((item,i)=>{
-      const [sym,pl] = item;
-      const cn = (window.SymbolCN && window.SymbolCN[sym]) || '';
+  const tbl = document.getElementById("leaderboard");
+  function renderBoard(list) {
+    tbl.innerHTML =
+      "<tr><th>#</th><th>代码</th><th>中文</th><th>累计盈亏</th></tr>";
+    list.forEach((item, i) => {
+      const [sym, pl] = item;
+      const cn = (window.SymbolCN && window.SymbolCN[sym]) || "";
       const cls = numberColor(pl);
-      tbl.insertAdjacentHTML('beforeend', `
+      tbl.insertAdjacentHTML(
+        "beforeend",
+        `
         <tr>
-          <td>${i+1}</td>
+          <td>${i + 1}</td>
           <td>${sym}</td>
           <td class="cn">${cn}</td>
           <td class="${cls}">${formatPnL(pl)}</td>
         </tr>
-      `);
+      `,
+      );
     });
-  };  // ← 加上分号
+  } // ← 加上分号
 
   renderBoard(profitList);
-  document.getElementById('tab-profit').onclick = ()=>{
-    document.getElementById('tab-profit').classList.add('active');
-    document.getElementById('tab-loss').classList.remove('active');
+  document.getElementById("tab-profit").onclick = () => {
+    document.getElementById("tab-profit").classList.add("active");
+    document.getElementById("tab-loss").classList.remove("active");
     renderBoard(profitList);
   };
-  document.getElementById('tab-loss').onclick = ()=>{
-    document.getElementById('tab-loss').classList.add('active');
-    document.getElementById('tab-profit').classList.remove('active');
+  document.getElementById("tab-loss").onclick = () => {
+    document.getElementById("tab-loss").classList.add("active");
+    document.getElementById("tab-profit").classList.remove("active");
     renderBoard(lossList);
   };
-
-})();  // end v7.7.3 IIFE
+})(); // end v7.7.3 IIFE
 
 /* ---- v7.8.1 新增: Alpha Vantage 收盘价 + 当日浮动盈亏 ---- */
-;(function(){
-  const today = nowNY().toISOString().slice(0,10);
+(function () {
+  const today = getLatestTradingDayStr();
 
   // Fetch Alpha Vantage key from KEY.txt (格式: Alpha key：XXXXX)
-  function fetchAlphaKey(){
-    return fetch('KEY.txt')
-      .then(r=>r.ok? r.text() : '')
-      .then(txt=>{
+  function fetchAlphaKey() {
+    return fetch("KEY.txt")
+      .then((r) => (r.ok ? r.text() : ""))
+      .then((txt) => {
         const m = txt.match(/Alpha\s+key：([A-Z0-9]+)/i);
-        return m ? m[1].trim() : '';
+        return m ? m[1].trim() : "";
       });
-  };  // ← 加上分号
+  } // ← 加上分号
 
   // 计算当前持仓平均成本
-  function calcOpenPositions(trades){
+  function calcOpenPositions(trades) {
     const pos = {};
-    trades.forEach(t=>{
-      const q = Number(t.qty), p = Number(t.price);
-      if(t.side==='BUY' || t.side==='COVER'){
-        const obj = pos[t.symbol]||(pos[t.symbol]={qty:0,cost:0});
+    trades.forEach((t) => {
+      const q = Number(t.qty),
+        p = Number(t.price);
+      if (t.side === "BUY" || t.side === "COVER") {
+        const obj = pos[t.symbol] || (pos[t.symbol] = { qty: 0, cost: 0 });
         const newQty = obj.qty + q;
-        obj.cost = (obj.cost*obj.qty + p*q)/newQty;
+        obj.cost = (obj.cost * obj.qty + p * q) / newQty;
         obj.qty = newQty;
-      } else if(t.side==='SELL' || t.side==='SHORT'){
-        const obj = pos[t.symbol]||(pos[t.symbol]={qty:0,cost:0});
+      } else if (t.side === "SELL" || t.side === "SHORT") {
+        const obj = pos[t.symbol] || (pos[t.symbol] = { qty: 0, cost: 0 });
         obj.qty -= q;
-        if(obj.qty<=0) delete pos[t.symbol];
+        if (obj.qty <= 0) delete pos[t.symbol];
       }
     });
     return pos;
-  };  // ← 加上分号
+  } // ← 加上分号
 
-  function fetchPrices(symbols, key){
+  function fetchPrices(symbols, key) {
     const result = {};
     let promise = Promise.resolve();
-    symbols.forEach(sym=>{
+    symbols.forEach((sym) => {
       promise = promise
-        .then(()=>fetch(
-          `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${sym}&apikey=${key}`
-        ))
-        .then(r=>r.json())
-        .then(js=>{
-          const price = Number(js['Global Quote']&&js['Global Quote']['05. price']);
-          if(price>0) result[sym]=price;
-          return new Promise(res=>setTimeout(res,15000));
+        .then(() =>
+          fetch(
+            `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${sym}&apikey=${key}`,
+          ),
+        )
+        .then((r) => r.json())
+        .then((js) => {
+          const price = Number(
+            js["Global Quote"] && js["Global Quote"]["05. price"],
+          );
+          if (price > 0) result[sym] = price;
+          return new Promise((res) => setTimeout(res, 15000));
         });
     });
-    return promise.then(()=>result);
-  };  // ← 加上分号
+    return promise.then(() => result);
+  } // ← 加上分号
 
-  async function updateCurveWithUnreal(){
+  async function updateCurveWithUnreal() {
     try {
-      const trades = JSON.parse(localStorage.getItem('trades')||'[]');
-      if(!trades.length) return;
+      const trades = JSON.parse(localStorage.getItem("trades") || "[]");
+      if (!trades.length) return;
       const positions = calcOpenPositions(trades);
       const symbols = Object.keys(positions);
-      if(!symbols.length) return;
+      if (!symbols.length) return;
 
       const key = await fetchAlphaKey();
-      if(!key){ console.warn('Alpha Vantage key missing'); return; }
+      if (!key) {
+        console.warn("Alpha Vantage key missing");
+        return;
+      }
 
       const prices = await fetchPrices(symbols, key);
       let unreal = 0;
-      symbols.forEach(sym=>{
-        if(prices[sym]){
+      symbols.forEach((sym) => {
+        if (prices[sym]) {
           const pos = positions[sym];
-          unreal += (prices[sym] - pos.cost)*pos.qty;
+          unreal += (prices[sym] - pos.cost) * pos.qty;
         }
       });
 
-      const idx = lineData.findIndex(i=>i[0]===today);
-      const newCum = (lineData.length ? Number(lineData[lineData.length-1][1]) : 0) + unreal;
-      if(idx>=0){
+      const idx = lineData.findIndex((i) => i[0] === today);
+      const newCum =
+        (lineData.length ? Number(lineData[lineData.length - 1][1]) : 0) +
+        unreal;
+      if (idx >= 0) {
         lineData[idx][1] = newCum.toFixed(2);
       } else {
         lineData.push([today, newCum.toFixed(2)]);
       }
 
-      if(typeof lineChart!=='undefined' && lineChart.setOption){
+      if (typeof lineChart !== "undefined" && lineChart.setOption) {
         lineChart.setOption({
-          xAxis: { data: lineData.map(i=>i[0]) },
-          series: [{ data: lineData.map(i=>i[1]) }]
+          xAxis: { data: lineData.map((i) => i[0]) },
+          series: [{ data: lineData.map((i) => i[1]) }],
         });
-      } else if(typeof window.pnlChartInstance!=='undefined'){
-        window.pnlChartInstance.data.labels   = lineData.map(i=>i[0]);
-        window.pnlChartInstance.data.datasets[0].data = lineData.map(i=>i[1]);
+      } else if (typeof window.pnlChartInstance !== "undefined") {
+        window.pnlChartInstance.data.labels = lineData.map((i) => i[0]);
+        window.pnlChartInstance.data.datasets[0].data = lineData.map(
+          (i) => i[1],
+        );
         window.pnlChartInstance.update();
       }
-    } catch(e){
-      console.error('updateCurveWithUnreal error', e);
+    } catch (e) {
+      console.error("updateCurveWithUnreal error", e);
     }
-  };  // ← 加上分号
+  } // ← 加上分号
 
   // initial call
   updateCurveWithUnreal();
-
-})();  // end v7.8.1 IIFE
+})(); // end v7.8.1 IIFE

--- a/apps/web/public/js/equityCurve.js
+++ b/apps/web/public/js/equityCurve.js
@@ -1,40 +1,41 @@
+(function () {
+  const { nowNY, toNY, getLatestTradingDayStr } = window;
+  const STORAGE_KEY = "equity_curve";
 
-(function(){
-  const { nowNY, toNY } = window;
-  const STORAGE_KEY = 'equity_curve';
-
-  function loadCurve(){
-    try{
-      return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
-    }catch(e){
+  function loadCurve() {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+    } catch (e) {
       return [];
     }
   }
 
-  function saveCurve(arr){
+  function saveCurve(arr) {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(arr));
   }
 
-  function exportCurve(){
-    const blob = new Blob([JSON.stringify(loadCurve())], {type:'application/json'});
+  function exportCurve() {
+    const blob = new Blob([JSON.stringify(loadCurve())], {
+      type: "application/json",
+    });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = 'equity_curve_' + Date.now() + '.json';
+    a.download = "equity_curve_" + Date.now() + ".json";
     document.body.appendChild(a);
     a.click();
     a.remove();
-    setTimeout(()=> URL.revokeObjectURL(url), 1000);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
 
-  function importCurve(file){
+  function importCurve(file) {
     const reader = new FileReader();
     reader.onload = () => {
-      try{
+      try {
         localStorage.setItem(STORAGE_KEY, reader.result);
-        alert('资金收益曲线已导入完成！');
-      }catch(e){
-        alert('导入失败: ' + e.message);
+        alert("资金收益曲线已导入完成！");
+      } catch (e) {
+        alert("导入失败: " + e.message);
       }
     };
     reader.readAsText(file);
@@ -46,99 +47,121 @@
   window.importCurve = importCurve;
 })();
 
-
 /* ---- v7.8.1 新增: Alpha Vantage 收盘价 & 当日浮动盈亏自动更新 ---- */
-(function(){
+(function () {
   // 若曲线里已存在今天数据且执行过，则跳过
-  const today = nowNY().toISOString().slice(0,10);
+  const today = getLatestTradingDayStr();
   const curve = loadCurve();
-  if(curve.some(p=> p.date===today && p.auto)) return;
+  if (curve.some((p) => p.date === today && p.auto)) return;
 
   // 读取交易记录
-  const trades = JSON.parse(localStorage.getItem('trades')||'[]');
-  if(!trades.length) return;
+  const trades = JSON.parse(localStorage.getItem("trades") || "[]");
+  if (!trades.length) return;
 
   /* 1. 计算持仓 */
-  function calcPositions(){
-    const pos={};
-    trades.sort((a,b)=> toNY(a.date)-toNY(b.date));
-    trades.forEach(t=>{
-      const s=t.symbol, q=Number(t.qty), price=Number(t.price);
-      if(t.side==='BUY' || t.side==='COVER'){
-         if(!pos[s]) pos[s]={qty:0,cost:0};
-         const newQty = pos[s].qty + q;
-         pos[s].cost = (pos[s].cost*pos[s].qty + price*q)/newQty;
-         pos[s].qty = newQty;
-      }else if(t.side==='SELL' || t.side==='SHORT'){
-         if(!pos[s]) return;
-         pos[s].qty -= q;
-         if(pos[s].qty<=0) delete pos[s];
+  function calcPositions() {
+    const pos = {};
+    trades.sort((a, b) => toNY(a.date) - toNY(b.date));
+    trades.forEach((t) => {
+      const s = t.symbol,
+        q = Number(t.qty),
+        price = Number(t.price);
+      if (t.side === "BUY" || t.side === "COVER") {
+        if (!pos[s]) pos[s] = { qty: 0, cost: 0 };
+        const newQty = pos[s].qty + q;
+        pos[s].cost = (pos[s].cost * pos[s].qty + price * q) / newQty;
+        pos[s].qty = newQty;
+      } else if (t.side === "SELL" || t.side === "SHORT") {
+        if (!pos[s]) return;
+        pos[s].qty -= q;
+        if (pos[s].qty <= 0) delete pos[s];
       }
     });
     return pos;
   }
   const positions = calcPositions();
   const symbols = Object.keys(positions);
-  if(!symbols.length) return;
+  if (!symbols.length) return;
 
   /* 2. 获取 Alpha Vantage key */
-  function getAlphaKey(){
-    return fetch('KEY.txt').then(r=> r.ok? r.text():'')
-      .then(txt=>{
+  function getAlphaKey() {
+    return fetch("KEY.txt")
+      .then((r) => (r.ok ? r.text() : ""))
+      .then((txt) => {
         const m = txt.match(/Alpha\s+key：([A-Z0-9]+)/i);
-        return m? m[1].trim(): '';
+        return m ? m[1].trim() : "";
       });
   }
 
   /* 3. 顺序拉取价格（每 15s 控速） */
-  function fetchPrices(key){
-    const prices={};
-    let p=Promise.resolve();
-    symbols.forEach(sym=>{
-      p=p.then(()=> fetch(`https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${sym}&apikey=${key}`))
-         .then(r=>r.json())
-         .then(js=>{
-            const price = Number(js['Global Quote']&&js['Global Quote']['05. price']);
-            if(price>0) prices[sym]=price;
-            return new Promise(r=> setTimeout(r,15000));
-         });
+  function fetchPrices(key) {
+    const prices = {};
+    let p = Promise.resolve();
+    symbols.forEach((sym) => {
+      p = p
+        .then(() =>
+          fetch(
+            `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${sym}&apikey=${key}`,
+          ),
+        )
+        .then((r) => r.json())
+        .then((js) => {
+          const price = Number(
+            js["Global Quote"] && js["Global Quote"]["05. price"],
+          );
+          if (price > 0) prices[sym] = price;
+          return new Promise((r) => setTimeout(r, 15000));
+        });
     });
-    return p.then(()=>prices);
+    return p.then(() => prices);
   }
 
-  async function run(){
-    const key=await getAlphaKey();
-    if(!key) { console.warn('Alpha key missing'); return; }
-    const priceMap=await fetchPrices(key);
+  async function run() {
+    const key = await getAlphaKey();
+    if (!key) {
+      console.warn("Alpha key missing");
+      return;
+    }
+    const priceMap = await fetchPrices(key);
 
-    let unreal=0;
-    symbols.forEach(sym=>{
-      const p=positions[sym];
-      if(priceMap[sym]) unreal += (priceMap[sym]-p.cost)*p.qty;
+    let unreal = 0;
+    symbols.forEach((sym) => {
+      const p = positions[sym];
+      if (priceMap[sym]) unreal += (priceMap[sym] - p.cost) * p.qty;
     });
 
     // 4. 计算累积净值
-    
-// 4. 计算当日已实现盈亏
-const todayReal = trades.filter(t=> t.date === today).reduce((s,t)=> s + (t.pl||0), 0);
 
-// 5. 计算当日浮动盈亏（unreal）已在上方得出
+    // 4. 计算当日已实现盈亏
+    const todayReal = trades
+      .filter((t) => t.date === today)
+      .reduce((s, t) => s + (t.pl || 0), 0);
 
-// 6. 计算 delta = 当日已实现盈亏 + 浮动盈亏变动
-const prevUnreal = curve.length ? curve[curve.length-1].value : 0;
-const delta = todayReal + (unreal - prevUnreal);
+    // 5. 计算当日浮动盈亏（unreal）已在上方得出
 
-// 7. 计算累积净值
-let cumulative = curve.length ? curve[curve.length-1].cumulative : 0;
-cumulative += delta;
+    // 6. 计算 delta = 当日已实现盈亏 + 浮动盈亏变动
+    const prevUnreal = curve.length ? curve[curve.length - 1].value : 0;
+    const delta = todayReal + (unreal - prevUnreal);
 
-const newPoint = {date: today, value: unreal, real: todayReal, delta, cumulative, auto:true};
-// 替换或 push
-const idx = curve.findIndex(p=> p.date === today);
-if(idx >= 0) curve[idx] = newPoint; else curve.push(newPoint);
-saveCurve(curve);
+    // 7. 计算累积净值
+    let cumulative = curve.length ? curve[curve.length - 1].cumulative : 0;
+    cumulative += delta;
 
-    console.log('资金收益曲线已自动更新', newPoint);
+    const newPoint = {
+      date: today,
+      value: unreal,
+      real: todayReal,
+      delta,
+      cumulative,
+      auto: true,
+    };
+    // 替换或 push
+    const idx = curve.findIndex((p) => p.date === today);
+    if (idx >= 0) curve[idx] = newPoint;
+    else curve.push(newPoint);
+    saveCurve(curve);
+
+    console.log("资金收益曲线已自动更新", newPoint);
   }
   run();
 })();

--- a/apps/web/public/js/services/priceService.js
+++ b/apps/web/public/js/services/priceService.js
@@ -4,7 +4,7 @@
  * No Node.js fs/path required – works on Vercel static hosting.
  */
 import { putPrice } from '../lib/idb.js';
-const { nowNY } = window;
+const { nowNY, getLatestTradingDayStr } = window;
 
 /** milliseconds to cache realtime quotes in localStorage */
 const RT_CACHE_MS = 60_000;
@@ -92,7 +92,7 @@ export async function fetchRealtimePrice(symbol){
  * Called by closeRecorder.js after market close.
  */
 export async function saveDailyClose(symbol, price){
-  const todayStr = nowNY().toISOString().slice(0,10);
+  const todayStr = getLatestTradingDayStr();
   await putPrice(symbol, todayStr, price, 'finnhub');
 }
 


### PR DESCRIPTION
## Summary
- add `getLatestTradingDayStr` utility for pre-open and weekend handling
- use `getLatestTradingDayStr` across metrics and price services
- add tests for `getLatestTradingDayStr` and update metric tests for market hours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689091fa5c04832ea768b9aedd59f210