### PR TITLE
Ensure period metrics ignore future daily results

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-period-future.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-period-future.test.ts
@@ -1,0 +1,25 @@
+import { calcMetrics, type DailyResult } from "@/lib/metrics";
+
+jest.mock("@/lib/timezone", () => {
+  const actual = jest.requireActual("@/lib/timezone");
+  return {
+    ...actual,
+    nowNY: () => new Date("2024-01-02T10:00:00-05:00"),
+  };
+});
+
+describe("calcMetrics period metrics exclude future dates", () => {
+  it("excludes daily results after today", () => {
+    const dailyResults: DailyResult[] = [
+      { date: "2024-01-01", realized: 100, float: 10, fifo: 5, M5_1: 0, pnl: 115 },
+      { date: "2024-01-02", realized: 200, float: 20, fifo: 10, M5_1: 0, pnl: 230 },
+      // Future date that should be ignored
+      { date: "2024-01-03", realized: 300, float: 30, fifo: 15, M5_1: 0, pnl: 345 },
+    ];
+
+    const metrics = calcMetrics([], [], dailyResults);
+    expect(metrics.M11).toBe(345);
+    expect(metrics.M12).toBe(345);
+    expect(metrics.M13).toBe(345);
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -469,7 +469,7 @@ function calcPeriodMetrics(
 ): { wtd: number; mtd: number; ytd: number } {
   const sumSince = (since: string) =>
     dailyResults
-      .filter((r) => r.date >= since)
+      .filter((r) => r.date >= since && r.date <= todayStr)
       .reduce((a, r) => a + r.realized + r.fifo + r.float, 0);
 
   // Ensure calculations are based on New York time


### PR DESCRIPTION
## Summary
- Ensure `calcPeriodMetrics` only sums daily results up to today
- Test that WTD/MTD/YTD calculations ignore future dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68909dbf9ddc832e8ea3825d70c8d334