### PR TITLE
Count trades strictly by action

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m7.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m7.test.ts
@@ -61,7 +61,7 @@ describe("calcMetrics M7 counts", () => {
     expect(metrics.M7).toEqual({ B: 2, S: 1, P: 2, C: 1, total: 6 });
   });
 
-  it("handles trades that both close and open positions", () => {
+  it("oversell/overcover only register original action", () => {
     const trades: Trade[] = [
       {
         symbol: "TSLA",
@@ -87,6 +87,6 @@ describe("calcMetrics M7 counts", () => {
     ];
 
     const metrics = calcMetrics(computeFifo(trades), []);
-    expect(metrics.M7).toEqual({ B: 2, S: 1, P: 1, C: 1, total: 5 });
+    expect(metrics.M7).toEqual({ B: 1, S: 1, P: 0, C: 1, total: 3 });
   });
 });


### PR DESCRIPTION
## Summary
- simplify `calcTodayTradeCounts` to count trades by `action`
- update M7 metrics test to ensure oversell/overcover trades only count once

## Testing
- `npm test`
- `npm run lint` *(fails: command sh -c next lint --max-warnings 0)*

------
https://chatgpt.com/codex/tasks/task_e_6890a0e12b6c832eba538cb5305df8aa