### PR TITLE
fix: count sell/cover trades once per record

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m7.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m7.test.ts
@@ -89,4 +89,75 @@ describe("calcMetrics M7 counts", () => {
     const metrics = calcMetrics(computeFifo(trades), []);
     expect(metrics.M7).toEqual({ B: 1, S: 1, P: 0, C: 1, total: 3 });
   });
+
+  it("counts sell/cover once even when split into multiple lots", () => {
+    const trades: Trade[] = [
+      {
+        id: 1,
+        symbol: "AAPL",
+        price: 100,
+        quantity: 100,
+        date: "2024-01-02T10:00:00-05:00",
+        action: "buy",
+      },
+      {
+        id: 2,
+        symbol: "AAPL",
+        price: 110,
+        quantity: 50,
+        date: "2024-01-02T11:00:00-05:00",
+        action: "buy",
+      },
+      {
+        id: 3,
+        symbol: "AAPL",
+        price: 120,
+        quantity: 150,
+        date: "2024-01-02T12:00:00-05:00",
+        action: "sell",
+      },
+      {
+        id: 4,
+        symbol: "MSFT",
+        price: 200,
+        quantity: 30,
+        date: "2024-01-02T09:00:00-05:00",
+        action: "short",
+      },
+      {
+        id: 5,
+        symbol: "MSFT",
+        price: 210,
+        quantity: 20,
+        date: "2024-01-02T09:30:00-05:00",
+        action: "short",
+      },
+      {
+        id: 6,
+        symbol: "MSFT",
+        price: 190,
+        quantity: 50,
+        date: "2024-01-02T13:00:00-05:00",
+        action: "cover",
+      },
+    ];
+
+    const enriched = computeFifo(trades);
+    const sell = enriched.find((t) => t.action === "sell")!;
+    const cover = enriched.find((t) => t.action === "cover")!;
+
+    const splitTrades = [
+      enriched.find((t) => t.id === 1)!,
+      enriched.find((t) => t.id === 2)!,
+      { ...sell, quantity: 100 },
+      { ...sell, quantity: 50 },
+      enriched.find((t) => t.id === 4)!,
+      enriched.find((t) => t.id === 5)!,
+      { ...cover, quantity: 20 },
+      { ...cover, quantity: 30 },
+    ];
+
+    const metrics = calcMetrics(splitTrades, []);
+    expect(metrics.M7).toEqual({ B: 2, S: 1, P: 2, C: 1, total: 6 });
+  });
 });

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -388,6 +388,9 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
   let P = 0;
   let C = 0;
 
+  const sellIds = new Set<number>();
+  const coverIds = new Set<number>();
+
   for (const t of trades) {
     if (!isTodayNY(t.date, todayStr)) continue;
     switch (t.action) {
@@ -395,13 +398,19 @@ function calcTodayTradeCounts(trades: EnrichedTrade[], todayStr: string) {
         B++;
         break;
       case "sell":
-        S++;
+        if (t.id === undefined || !sellIds.has(t.id)) {
+          S++;
+          if (t.id !== undefined) sellIds.add(t.id);
+        }
         break;
       case "short":
         P++;
         break;
       case "cover":
-        C++;
+        if (t.id === undefined || !coverIds.has(t.id)) {
+          C++;
+          if (t.id !== undefined) coverIds.add(t.id);
+        }
         break;
     }
   }


### PR DESCRIPTION
## Summary
- dedupe sell and cover trade counts by trade id so each counts once regardless of FIFO lots
- add test ensuring split sell/cover lots only increment S and C once

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6890a6a50328832e9f47dadec9eb62e7