### PR TITLE
Use latest trading day helper for closing price fetch

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link';
 import { calcMetrics } from '@/lib/metrics';
 import { useStore } from '@/lib/store';
 import { fetchRealtimeQuote, fetchDailyClose } from '@/lib/services/priceService';
+import { getLatestTradingDayStr } from '@/lib/timezone';
 
 async function computeDataHash(data: unknown): Promise<string> {
   const json = JSON.stringify(data);
@@ -102,7 +103,7 @@ export default function DashboardPage() {
           try {
             let result = await fetchRealtimeQuote(pos.symbol);
             if (!result || result.price === 1) {
-              const today = new Date().toISOString().slice(0, 10);
+              const today = getLatestTradingDayStr();
               result = await fetchDailyClose(pos.symbol, today);
             }
 
@@ -197,7 +198,7 @@ export default function DashboardPage() {
         try {
           let result = await fetchRealtimeQuote(pos.symbol);
           if (!result || result.price === 1) {
-            const today = new Date().toISOString().slice(0, 10);
+            const today = getLatestTradingDayStr();
             result = await fetchDailyClose(pos.symbol, today);
           }
           if (result && result.price && result.price !== 1) {


### PR DESCRIPTION
## Summary
- use `getLatestTradingDayStr` instead of `new Date().toISOString().slice(0,10)` when falling back to daily close pricing

## Testing
- `npm test`
- `npm run lint` *(fails: `next lint --max-warnings 0`)*

------
https://chatgpt.com/codex/tasks/task_e_6890a8a51a04832ebcd38085ad8fce62