### PR TITLE
feat: handle initial positions in metrics

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-trades-json-historical.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-trades-json-historical.test.ts
@@ -1,0 +1,55 @@
+import tradesData from '../../../public/trades.json';
+import { computeFifo, type InitialPosition } from '@/lib/fifo';
+import { calcMetrics } from '@/lib/metrics';
+import type { Trade, Position } from '@/lib/services/dataService';
+
+jest.mock('@/lib/timezone', () => {
+  const actual = jest.requireActual('@/lib/timezone');
+  return {
+    ...actual,
+    nowNY: () => new Date('2025-08-01T10:00:00-04:00'),
+  };
+});
+
+describe('calcMetrics with trades.json historical lots', () => {
+  it('matches expected M4, M5 and M10 values', () => {
+    const initialPositions: InitialPosition[] = tradesData.positions.map(p => ({
+      symbol: p.symbol,
+      qty: p.qty,
+      avgPrice: p.avgPrice,
+    }));
+    const trades: Trade[] = tradesData.trades.map((t, idx) => ({
+      id: idx,
+      symbol: t.symbol,
+      price: t.price,
+      quantity: t.qty,
+      date: t.date,
+      action: t.side.toLowerCase() as Trade['action'],
+    }));
+    const enriched = computeFifo(trades, initialPositions);
+    const posMap = new Map<string, Position>(
+      initialPositions.map(p => [p.symbol, { ...p, last: p.avgPrice, priceOk: true }])
+    );
+    for (const t of enriched) {
+      if (t.quantityAfter !== 0) {
+        posMap.set(t.symbol, {
+          symbol: t.symbol,
+          qty: t.quantityAfter,
+          avgPrice: t.averageCost,
+          last: t.averageCost,
+          priceOk: true,
+        });
+      } else {
+        posMap.delete(t.symbol);
+      }
+    }
+    const positions: Position[] = Array.from(posMap.values());
+    const metrics = calcMetrics(enriched, positions, [], initialPositions);
+    expect(metrics.M4).toBe(6530);
+    expect(metrics.M5.trade).toBe(1670);
+    expect(metrics.M5.fifo).toBe(1320);
+    expect(metrics.M10.W).toBe(11);
+    expect(metrics.M10.L).toBe(2);
+    expect(metrics.M10.rate).toBeCloseTo(84.61538, 5);
+  });
+});

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -139,12 +139,17 @@ export default function DashboardPage() {
         const dailyResults = dailyResultsResponse.ok ? await dailyResultsResponse.json() : [];
 
         // 计算指标并存入全局状态
-        const metrics = calcMetrics(enriched, posList, dailyResults);
+        const initPos = dbPositions.map(({ symbol, qty, avgPrice }) => ({
+          symbol,
+          qty,
+          avgPrice,
+        }));
+        const metrics = calcMetrics(enriched, posList, dailyResults, initPos);
         useStore.getState().setMetrics(metrics);
 
         setTrades(dbTrades);
         setPositions(posList);
-        setInitialPositions(dbPositions.map(({ symbol, qty, avgPrice }) => ({ symbol, qty, avgPrice })));
+        setInitialPositions(initPos);
       } catch (e) {
         console.error(e);
         setError(e instanceof Error ? e.message : 'An unknown error occurred.');
@@ -224,12 +229,17 @@ export default function DashboardPage() {
       const dailyResults = dailyResultsResponse.ok ? await dailyResultsResponse.json() : [];
 
       // 计算指标并更新全局状态
-      const metrics = calcMetrics(enriched, posList, dailyResults);
+      const initPos = dbPositions.map(({ symbol, qty, avgPrice }) => ({
+        symbol,
+        qty,
+        avgPrice,
+      }));
+      const metrics = calcMetrics(enriched, posList, dailyResults, initPos);
       useStore.getState().setMetrics(metrics);
 
       setTrades(dbTrades);
       setPositions(posList);
-      setInitialPositions(dbPositions.map(({ symbol, qty, avgPrice }) => ({ symbol, qty, avgPrice })));
+      setInitialPositions(initPos);
     } catch (e) { console.error(e); }
   }
 


### PR DESCRIPTION
## Summary
- preload historical lots into FIFO-based PnL and win/loss calculations
- pass stored initial positions through calcMetrics and page logic
- verify FIFO metrics with sample trades.json including historical lots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890aea82ef8832ebb2d2436d1ba78d4