### PR TITLE
Filter future daily results in M9

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m9-ignore-future.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m9-ignore-future.test.ts
@@ -1,0 +1,23 @@
+import { calcMetrics, type DailyResult } from "@/lib/metrics";
+
+jest.mock("@/lib/timezone", () => {
+  const actual = jest.requireActual("@/lib/timezone");
+  return {
+    ...actual,
+    nowNY: () => new Date("2024-01-02T10:00:00-05:00"),
+  };
+});
+
+describe("calcMetrics M9 ignores future dailyResults", () => {
+  it("excludes future daily results from M9", () => {
+    const dailyResults: DailyResult[] = [
+      { date: "2024-01-01", realized: 100, float: 0, fifo: 10, M5_1: 0, pnl: 110 },
+      { date: "2024-01-02", realized: 200, float: 0, fifo: 20, M5_1: 0, pnl: 220 },
+      // Future date that should be ignored
+      { date: "2024-01-03", realized: 300, float: 0, fifo: 30, M5_1: 0, pnl: 330 },
+    ];
+
+    const metrics = calcMetrics([], [], dailyResults);
+    expect(metrics.M9).toBe(330);
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -578,7 +578,9 @@ export function calcMetrics(
 
   // M9: 所有历史平仓盈利（含今日）
   const historicalRealizedPnl = dailyResults.length
-    ? dailyResults.reduce((acc, r) => acc + r.realized + r.fifo, 0)
+    ? dailyResults
+        .filter((r) => r.date <= todayStr)
+        .reduce((acc, r) => acc + r.realized + r.fifo, 0)
     : trades.reduce((acc, t) => acc + (t.realizedPnl || 0), 0);
   if (DEBUG) console.log("M9计算结果:", historicalRealizedPnl);
 


### PR DESCRIPTION
## Summary
- ignore future dailyResults when computing historical realized PnL (M9)
- add unit test verifying M9 excludes future daily results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890b26a9d4c832ea4c196ca1cf0fb34