### PR TITLE
Filter future daily results for M9

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m9-future-only.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m9-future-only.test.ts
@@ -1,0 +1,47 @@
+import { computeFifo } from "@/lib/fifo";
+import { calcMetrics, type DailyResult } from "@/lib/metrics";
+import type { Trade } from "@/lib/services/dataService";
+
+jest.mock("@/lib/timezone", () => {
+  const actual = jest.requireActual("@/lib/timezone");
+  return {
+    ...actual,
+    nowNY: () => new Date("2024-01-02T10:00:00-05:00"),
+  };
+});
+
+describe("calcMetrics M9 falls back to trades when dailyResults are future only", () => {
+  it("uses trade realized pnl if all daily results are in the future", () => {
+    const trades: Trade[] = [
+      {
+        symbol: "AAPL",
+        price: 100,
+        quantity: 100,
+        date: "2024-01-01",
+        action: "buy",
+      },
+      {
+        symbol: "AAPL",
+        price: 110,
+        quantity: 100,
+        date: "2024-01-02",
+        action: "sell",
+      },
+    ];
+
+    const enriched = computeFifo(trades);
+    const dailyResults: DailyResult[] = [
+      {
+        date: "2024-01-03",
+        realized: 1000,
+        float: 0,
+        fifo: 0,
+        M5_1: 0,
+        pnl: 1000,
+      },
+    ];
+
+    const metrics = calcMetrics(enriched, [], dailyResults);
+    expect(metrics.M9).toBe(1000);
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -576,11 +576,11 @@ export function calcMetrics(
     allTradesByType.P +
     allTradesByType.C;
 
+  const historicalDailyResults = dailyResults.filter((r) => r.date <= todayStr);
+
   // M9: 所有历史平仓盈利（含今日）
-  const historicalRealizedPnl = dailyResults.length
-    ? dailyResults
-        .filter((r) => r.date <= todayStr)
-        .reduce((acc, r) => acc + r.realized + r.fifo, 0)
+  const historicalRealizedPnl = historicalDailyResults.length
+    ? historicalDailyResults.reduce((acc, r) => acc + r.realized + r.fifo, 0)
     : trades.reduce((acc, t) => acc + (t.realizedPnl || 0), 0);
   if (DEBUG) console.log("M9计算结果:", historicalRealizedPnl);
 
@@ -595,7 +595,7 @@ export function calcMetrics(
       : 0;
 
   // M11-13: 周期性指标
-  const { wtd, mtd, ytd } = calcPeriodMetrics(dailyResults, todayStr);
+  const { wtd, mtd, ytd } = calcPeriodMetrics(historicalDailyResults, todayStr);
 
   return {
     M1: totalCost,


### PR DESCRIPTION
## Summary
- filter dailyResults by todayStr before computing historical realized PnL
- reuse filtered daily results for period metrics
- cover case where dailyResults only contain future dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890b4eb5218832eb17124cd94622873