### PR TITLE
feat: support price freeze date

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -34,6 +34,10 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load Inter, a custom Google Font.
 
+## Freeze date for debugging
+
+To debug against a fixed market snapshot, set `NEXT_PUBLIC_FREEZE_DATE` in your `.env` file to the last Friday's date (e.g. `2024-05-17`). When this variable is present the app serves that day's closing prices instead of live quotes. Remove the variable to resume live pricing.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import { Header } from "@/components/layout/Header";
 import Providers from "./providers";
 
@@ -19,6 +20,9 @@ export default function RootLayout({
   return (
     <html lang="zh-CN">
       <body className={inter.className} suppressHydrationWarning>
+        <Script id="freeze-date" strategy="beforeInteractive">
+          {`window.NEXT_PUBLIC_FREEZE_DATE=${JSON.stringify(process.env.NEXT_PUBLIC_FREEZE_DATE || "")};`}
+        </Script>
         <Providers>
           <div className="flex flex-col min-h-screen">
             <Header />

--- a/apps/web/app/lib/services/priceService.ts
+++ b/apps/web/app/lib/services/priceService.ts
@@ -22,6 +22,7 @@ async function saveToFile(symbol: string, date: string, close: number) {
  */
 const finnhubToken = process.env.NEXT_PUBLIC_FINNHUB_TOKEN;
 const tiingoToken = process.env.NEXT_PUBLIC_TIINGO_TOKEN;
+const freezeDate = process.env.NEXT_PUBLIC_FREEZE_DATE;
 
 /**
  * 从文件加载的 API 令牌缓存
@@ -308,6 +309,12 @@ export async function fetchDailyClose(symbol: string, date: string): Promise<Quo
  * @returns 实时价格
  */
 export async function fetchRealtimeQuote(symbol: string): Promise<QuoteResult> {
+  // 当设置了冻结日期时，直接返回该日的收盘价
+  if (freezeDate) {
+    const { price } = await fetchDailyClose(symbol, freezeDate);
+    return { price, stale: false };
+  }
+
   try {
     // 直接从 Finnhub 获取实时报价
     const finnhubPrice = await fetchFinnhubRealtimeQuote(symbol);

--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -80,6 +80,12 @@ export const formatNY = (
  * 返回格式为 YYYY-MM-DD。
  */
 export const getLatestTradingDayStr = (base: Date = nowNY()): string => {
+  const freeze =
+    (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_FREEZE_DATE) ||
+    // @ts-ignore
+    (typeof window !== 'undefined' && (window as any).NEXT_PUBLIC_FREEZE_DATE);
+  if (freeze) return freeze as string;
+
   const d = toNY(base);
   if (d.getHours() < 9 || (d.getHours() === 9 && d.getMinutes() < 30)) {
     d.setDate(d.getDate() - 1);

--- a/apps/web/public/js/services/priceService.js
+++ b/apps/web/public/js/services/priceService.js
@@ -4,6 +4,7 @@
  * No Node.js fs/path required – works on Vercel static hosting.
  */
 import { putPrice } from '../lib/idb.js';
+import { fetchDailyClose } from './finnhubService.js';
 const { nowNY, getLatestTradingDayStr } = window;
 
 /** milliseconds to cache realtime quotes in localStorage */
@@ -64,6 +65,16 @@ function resolveFinnhubToken(raw){
 }
 
 export async function fetchRealtimePrice(symbol){
+  const freeze = window.NEXT_PUBLIC_FREEZE_DATE;
+  if(freeze){
+    try{
+      return await fetchDailyClose(symbol, freeze);
+    }catch(e){
+      console.error('[priceService] fetchRealtimePrice freeze', symbol, e);
+      return null;
+    }
+  }
+
   const cacheKey = `rt_${symbol}`;
   try{
     const cached = JSON.parse(localStorage.getItem(cacheKey)||'null');

--- a/env.example
+++ b/env.example
@@ -16,5 +16,7 @@ VERCEL_URL=
 VERCEL_ENV=production
 
 # Application settings
+# Optional: freeze all price lookups to a specific trading day (YYYY-MM-DD)
+NEXT_PUBLIC_FREEZE_DATE=
 NEXT_PUBLIC_APP_URL=https://your-domain.com
 NODE_ENV=production


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_FREEZE_DATE to sample env and expose it to the browser
- allow price services to return a specified day's close instead of live quotes
- support frozen date for metrics and document how to use the variable

## Testing
- `npm test`
- `npm run lint -w web` *(fails: next lint --max-warnings 0)*

------
https://chatgpt.com/codex/tasks/task_e_6890da8a4fd0832e93345f7c87bdeaf9