### PR TITLE
chore: update positions with new market data

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-trades-json-historical.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-trades-json-historical.test.ts
@@ -45,9 +45,9 @@ describe('calcMetrics with trades.json historical lots', () => {
     }
     const positions: Position[] = Array.from(posMap.values());
     const metrics = calcMetrics(enriched, positions, [], initialPositions);
-    expect(metrics.M4).toBe(6530);
+    expect(metrics.M4).toBe(6880);
     expect(metrics.M5.trade).toBe(1670);
-    expect(metrics.M5.fifo).toBe(1320);
+    expect(metrics.M5.fifo).toBe(1050);
     expect(metrics.M10.W).toBe(11);
     expect(metrics.M10.L).toBe(2);
     expect(metrics.M10.rate).toBeCloseTo(84.61538, 5);

--- a/apps/web/public/trades.json
+++ b/apps/web/public/trades.json
@@ -4,22 +4,43 @@
       "symbol": "TSLA",
       "qty": 50,
       "avgPrice": 290,
-      "last": 290,
-      "priceOk": false
+      "last": 305,
+      "priceOk": true
     },
     {
       "symbol": "NFLX",
       "qty": 100,
       "avgPrice": 1100,
-      "last": 1100,
-      "priceOk": false
+      "last": 1165,
+      "priceOk": true
     },
     {
       "symbol": "AMZN",
       "qty": -80,
       "avgPrice": 220,
-      "last": 220,
-      "priceOk": false
+      "last": 215,
+      "priceOk": true
+    },
+    {
+      "symbol": "AAPL",
+      "qty": 0,
+      "avgPrice": 0,
+      "last": 199,
+      "priceOk": true
+    },
+    {
+      "symbol": "GOOGL",
+      "qty": -50,
+      "avgPrice": 194,
+      "last": 190,
+      "priceOk": true
+    },
+    {
+      "symbol": "MSFT",
+      "qty": 50,
+      "avgPrice": 520,
+      "last": 523,
+      "priceOk": true
     }
   ],
   "trades": [


### PR DESCRIPTION
## Summary
- refresh TSLA, NFLX, AMZN last prices
- add AAPL, GOOGL and MSFT positions to trades dataset
- adjust metrics test expectations for new dataset

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68912a409dec832eb8b9585a5ffa71ea