### PR TITLE
feat: dedupe trade counts for metrics

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m7.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m7.test.ts
@@ -59,6 +59,7 @@ describe("calcMetrics M7 counts", () => {
 
     const metrics = calcMetrics(computeFifo(trades), []);
     expect(metrics.M7).toEqual({ B: 2, S: 1, P: 2, C: 1, total: 6 });
+    expect(metrics.M8).toEqual({ B: 2, S: 1, P: 2, C: 1, total: 6 });
   });
 
   it("oversell/overcover only register original action", () => {
@@ -88,6 +89,7 @@ describe("calcMetrics M7 counts", () => {
 
     const metrics = calcMetrics(computeFifo(trades), []);
     expect(metrics.M7).toEqual({ B: 1, S: 1, P: 0, C: 1, total: 3 });
+    expect(metrics.M8).toEqual({ B: 1, S: 1, P: 0, C: 1, total: 3 });
   });
 
   it("counts sell/cover once even when split into multiple lots", () => {
@@ -159,5 +161,6 @@ describe("calcMetrics M7 counts", () => {
 
     const metrics = calcMetrics(splitTrades, []);
     expect(metrics.M7).toEqual({ B: 2, S: 1, P: 2, C: 1, total: 6 });
+    expect(metrics.M8).toEqual({ B: 2, S: 1, P: 2, C: 1, total: 6 });
   });
 });

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -563,18 +563,48 @@ export function calcMetrics(
     todayTradeCountsByType.P +
     todayTradeCountsByType.C;
 
-  // M8: 累计交易次数
-  const allTradesByType = {
-    B: trades.filter((t) => t.action === "buy").length,
-    S: trades.filter((t) => t.action === "sell").length,
-    P: trades.filter((t) => t.action === "short").length,
-    C: trades.filter((t) => t.action === "cover").length,
-  };
-  const totalTrades =
-    allTradesByType.B +
-    allTradesByType.S +
-    allTradesByType.P +
-    allTradesByType.C;
+  // M8: 累计交易次数（按唯一交易ID计数）
+  let B = 0;
+  let S = 0;
+  let P = 0;
+  let C = 0;
+
+  const buyIds = new Set<number>();
+  const sellIds = new Set<number>();
+  const shortIds = new Set<number>();
+  const coverIds = new Set<number>();
+
+  for (const t of trades) {
+    switch (t.action) {
+      case "buy":
+        if (t.id === undefined || !buyIds.has(t.id)) {
+          B++;
+          if (t.id !== undefined) buyIds.add(t.id);
+        }
+        break;
+      case "sell":
+        if (t.id === undefined || !sellIds.has(t.id)) {
+          S++;
+          if (t.id !== undefined) sellIds.add(t.id);
+        }
+        break;
+      case "short":
+        if (t.id === undefined || !shortIds.has(t.id)) {
+          P++;
+          if (t.id !== undefined) shortIds.add(t.id);
+        }
+        break;
+      case "cover":
+        if (t.id === undefined || !coverIds.has(t.id)) {
+          C++;
+          if (t.id !== undefined) coverIds.add(t.id);
+        }
+        break;
+    }
+  }
+
+  const allTradesByType = { B, S, P, C };
+  const totalTrades = B + S + P + C;
 
   const historicalDailyResults = dailyResults.filter((r) => r.date <= todayStr);
 


### PR DESCRIPTION
## Summary
- count unique trade IDs for cumulative trade metrics
- ensure metrics tests validate deduped cumulative counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891385ae488832ea6a5cfee5f771835