### PR TITLE
chore(ci): add skip-ci guard for codex edits [skip ci]

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -1,0 +1,14 @@
+name: guard
+on:
+  push:
+  pull_request:
+jobs:
+  guard:
+    if: >
+      ${{ !contains(github.event.head_commit.message, '[skip ci]')
+          && !contains(github.event.pull_request.title, '[skip ci]')
+          && !contains(github.event.pull_request.body, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "CI running (no [skip ci] found)"


### PR DESCRIPTION
## Summary
- add guard workflow that skips CI when commit message or PR title/body include `[skip ci]`

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6897860a7c20832e8ab8bf87e2a6d278