### PR TITLE
feat: add resilient data loader

### DIFF
--- a/apps/web/app/lib/dataSource.ts
+++ b/apps/web/app/lib/dataSource.ts
@@ -1,0 +1,22 @@
+export async function loadJson(name: 'trades'|'initial_positions'|'close_prices') {
+  const url = `/${name}.json`;
+  try {
+    const res = await fetch(url);
+    if (res.ok) {
+      const data = await res.json();
+      if (data && (Array.isArray(data) ? data.length > 0 : Object.keys(data).length > 0)) {
+        return data;
+      }
+    }
+  } catch {
+    // ignore fetch errors
+  }
+  switch (name) {
+    case 'trades':
+      return (await import('../../public/trades.json')).default;
+    case 'initial_positions':
+      return (await import('../../public/initial_positions.json')).default;
+    case 'close_prices':
+      return (await import('../../public/close_prices.json')).default;
+  }
+}

--- a/apps/web/app/lib/services/priceService.ts
+++ b/apps/web/app/lib/services/priceService.ts
@@ -1,4 +1,5 @@
 import { getPrice, putPrice, CachedPrice } from './dataService';
+import { loadJson } from '@/app/lib/dataSource';
 // 所有外部 API 调用都通过 apiQueue 进行排队以防止触发速率限制
 import { apiQueue } from './apiQueue';
 
@@ -281,7 +282,7 @@ export async function fetchDailyClose(symbol: string, date: string): Promise<Quo
 
     // 尝试从 close_prices.json 文件获取
     try {
-      const closePrices = await fetch('/close_prices.json').then(r => r.json()) as Record<string, Record<string, number>>;
+      const closePrices = await loadJson('close_prices') as Record<string, Record<string, number>>;
       const filePrice = closePrices?.[date]?.[symbol];
       if (typeof filePrice === 'number') {
         await putPrice({ symbol, date, close: filePrice, source: 'import' });

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useMemo } from 'react';
 import { importData, findTrades, clearAllData, findPositions } from '@/lib/services/dataService';
+import { loadJson } from '@/app/lib/dataSource';
 import type { Trade, Position } from '@/lib/services/dataService';
 import { computeFifo, type InitialPosition } from '@/lib/fifo';
 import { DashboardMetrics } from '@/modules/DashboardMetrics';
@@ -51,11 +52,9 @@ export default function DashboardPage() {
       try {
         setIsLoading(true);
 
-        const response = await fetch('/trades.json');
-        if (!response.ok) {
-          throw new Error('Failed to fetch trades.json');
-        }
-        const rawData = await response.json();
+        const tradesFile = await loadJson('trades');
+        const initPositionsFile = await loadJson('initial_positions');
+        const rawData = { trades: tradesFile, positions: initPositionsFile };
 
         const newHash = await computeDataHash(rawData);
 

--- a/apps/web/app/positions/page.tsx
+++ b/apps/web/app/positions/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { importData } from "@/lib/services/dataService";
 import { findTrades } from "@/lib/services/dataService";
+import { loadJson } from "@/app/lib/dataSource";
 import type { Position } from "@/lib/services/dataService";
 import { computeFifo, type EnrichedTrade } from "@/lib/fifo";
 import { PositionsTable } from "@/modules/PositionsTable";
@@ -21,12 +22,10 @@ export default function PositionsPage() {
         // 先查询是否已有交易数据，若没有则导入示例数据
         let allTrades = await findTrades();
         if (allTrades.length === 0) {
-          const response = await fetch("/trades.json");
-          if (response.ok) {
-            const rawData = await response.json();
-            await importData(rawData);
-            allTrades = await findTrades();
-          }
+          const tradesFile = await loadJson('trades');
+          const initPositionsFile = await loadJson('initial_positions');
+          await importData({ trades: tradesFile, positions: initPositionsFile });
+          allTrades = await findTrades();
         }
 
         const enriched = computeFifo(allTrades);

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { importData, findTrades } from './lib/services/dataService';
+import { loadJson } from '@/app/lib/dataSource';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
@@ -15,11 +16,9 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         const storedHash = localStorage.getItem('dataset-hash');
         const trades = await findTrades();
         if (!storedHash && trades.length === 0) {
-          const res = await fetch('/trades.json');
-          if (res.ok) {
-            const raw = await res.json();
-            await importData(raw);
-          }
+          const tradesFile = await loadJson('trades');
+          const initPositionsFile = await loadJson('initial_positions');
+          await importData({ trades: tradesFile, positions: initPositionsFile });
         }
       } catch (_) {
         // optional: ignore errors when demo file missing

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "@/app/*": [
+        "./app/*"
+      ],
       "@/*": [
         "./app/*"
       ],


### PR DESCRIPTION
## Summary
- fallback to embedded JSON data when fetch fails
- load trades, positions and price JSON via shared helper

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68979772f108832e9eeb9ea3fc9e8ffa