### PR TITLE
test: add golden M7 metrics test

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m7-golden.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m7-golden.test.ts
@@ -1,0 +1,8 @@
+import { calcMetrics } from "@/lib/metrics";
+import trades from "../../public/trades.json";
+import initial from "../../public/initial_positions.json";
+
+test('golden case M7 counts', () => {
+  const metrics = calcMetrics(trades as any, [] as any, [], initial as any);
+  expect(metrics.M7).toEqual({ B:6, S:8, P:4, C:4, total:22 });
+});


### PR DESCRIPTION
## Summary
- add golden case unit test for M7 trade counts using sample trades and initial positions

## Testing
- `npm test -- apps/web/app/lib/__tests__/metrics-m7-golden.test.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897c3179778832ea906aa1c78ecd08a