### PR TITLE
Add daily result validation and test for period metrics

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-dailyResult-validation.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-dailyResult-validation.test.ts
@@ -1,0 +1,21 @@
+import { calcPeriodMetrics, type DailyResult } from "@/lib/metrics";
+
+describe("calcPeriodMetrics validates DailyResult consistency", () => {
+  it("throws and warns when components do not sum to pnl", () => {
+    const invalid: DailyResult = {
+      date: "2024-01-02",
+      realized: 100,
+      fifo: 10,
+      float: 5,
+      M5_1: 0,
+      pnl: 999,
+    };
+
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() => calcPeriodMetrics([invalid], "2024-01-02")).toThrow(
+      /DailyResult mismatch/,
+    );
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -132,6 +132,23 @@ function round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
 
+/**
+ * Validate consistency of a DailyResult entry.
+ * Throws an error (and warns) if realized + fifo + float does not equal pnl.
+ */
+export function validateDailyResult(r: DailyResult): void {
+  const total = round2(r.realized + r.fifo + r.float);
+  const pnl = round2(r.pnl);
+  if (total !== pnl) {
+    const msg =
+      `DailyResult mismatch on ${r.date}: ` +
+      `realized(${r.realized}) + fifo(${r.fifo}) + float(${r.float}) = ${total}, ` +
+      `but pnl is ${r.pnl}`;
+    console.warn(msg);
+    throw new Error(msg);
+  }
+}
+
 function _count(list: { action?: string }[] | undefined) {
   const res = { B: 0, S: 0, P: 0, C: 0, total: 0 };
   if (!Array.isArray(list)) return res;
@@ -495,10 +512,11 @@ function calcCumulativeTradeCounts(
  * @param todayStr 今日日期字符串，格式为 YYYY-MM-DD
  * @returns 包含 wtd、mtd、ytd 的对象
  */
-function calcPeriodMetrics(
+export function calcPeriodMetrics(
   dailyResults: DailyResult[],
   todayStr: string,
 ): { wtd: number; mtd: number; ytd: number } {
+  dailyResults.forEach(validateDailyResult);
   const sumSince = (since: string) =>
     dailyResults
       .filter((r) => r.date >= since && r.date <= todayStr)


### PR DESCRIPTION
## Summary
- validate DailyResult entries and throw when values do not sum to pnl
- run validation within `calcPeriodMetrics` before computing aggregates
- add unit test covering mismatched DailyResult data

## Testing
- `npm test apps/web/app/lib/__tests__/metrics-dailyResult-validation.test.ts` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897cf4bae9c832e8b9d29c93c980122