### PR TITLE
refactor: centralize period metrics helpers

### DIFF
--- a/apps/web/app/lib/metrics-period.ts
+++ b/apps/web/app/lib/metrics-period.ts
@@ -1,0 +1,23 @@
+import type { DailyResult } from "./types";
+import { weekStartNY, monthStartNY, yearStartNY } from "./timezone";
+
+export function sumRealized(days: Pick<DailyResult, "realized">[]): number {
+  return days.reduce((total, d) => total + d.realized, 0);
+}
+
+export function calcPeriodMetrics(
+  days: DailyResult[],
+  currentNyDate: string,
+): { wtd: number; mtd: number; ytd: number } {
+  const sum = (from: string) =>
+    days
+      .filter((r) => r.date >= from && r.date <= currentNyDate)
+      .reduce((acc, r) => acc + r.realized + r.unrealized, 0);
+
+  return {
+    wtd: sum(weekStartNY(currentNyDate)),
+    mtd: sum(monthStartNY(currentNyDate)),
+    ytd: sum(yearStartNY(currentNyDate)),
+  };
+}
+

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -3,6 +3,7 @@ import type { Position } from "@/lib/services/dataService";
 import { nowNY, toNY, getLatestTradingDayStr, endOfDayNY } from "@/lib/timezone";
 import { calcTodayTradePnL } from "./calcTodayTradePnL";
 import type { DailyResult } from "./types";
+import { calcPeriodMetrics } from "./metrics-period";
 
 // Only enable verbose logging outside production
 const DEBUG = process.env.NODE_ENV !== "production";
@@ -473,29 +474,6 @@ function calcCumulativeTradeCounts(
  * @param todayStr 今日日期字符串，格式为 YYYY-MM-DD
  * @returns 包含 wtd、mtd、ytd 的对象
  */
-export function calcPeriodMetrics(
-  dailyResults: DailyResult[],
-  todayStr: string,
-): { wtd: number; mtd: number; ytd: number } {
-  const sumSince = (since: string) =>
-    dailyResults
-      .filter((r) => r.date >= since && r.date <= todayStr)
-      .reduce((a, r) => a + r.realized + r.unrealized, 0);
-
-  // Ensure calculations are based on New York time
-  const today = toNY(`${todayStr}T00:00:00`);
-  const day = (today.getDay() + 6) % 7; // Monday=0
-  const monday = toNY(today);
-  monday.setDate(today.getDate() - day);
-  const mondayStr = monday.toISOString().slice(0, 10);
-
-  return {
-    wtd: sumSince(mondayStr),
-    mtd: sumSince(todayStr.slice(0, 8) + "01"),
-    ytd: sumSince(todayStr.slice(0, 4) + "-01-01"),
-  };
-}
-
 /**
  * 计算所有交易指标
  *

--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -103,6 +103,28 @@ export const endOfDayNY = (date: Date): Date => {
   return d;
 };
 
+/** 获取所在周的周一日期（纽约时区），返回 YYYY-MM-DD */
+export const weekStartNY = (dateInput: string | Date): string => {
+  const d = toNY(dateInput);
+  const day = (d.getDay() + 6) % 7;
+  d.setDate(d.getDate() - day);
+  return d.toISOString().slice(0, 10);
+};
+
+/** 获取所在月的月初日期（纽约时区），返回 YYYY-MM-DD */
+export const monthStartNY = (dateInput: string | Date): string => {
+  const d = toNY(dateInput);
+  d.setDate(1);
+  return d.toISOString().slice(0, 10);
+};
+
+/** 获取所在年的年初日期（纽约时区），返回 YYYY-MM-DD */
+export const yearStartNY = (dateInput: string | Date): string => {
+  const d = toNY(dateInput);
+  d.setMonth(0, 1);
+  return d.toISOString().slice(0, 10);
+};
+
 // Attach helper to global for quick usage in dev tools
 // @ts-ignore
 (globalThis as any).toNY = toNY;


### PR DESCRIPTION
## Summary
- add metrics-period helper with sumRealized and calcPeriodMetrics
- use new period metrics helper in metrics calculations
- add week/month/year start helpers for NY timezone

## Testing
- `npx --yes jest` *(fails: Preset ts-jest not found relative to rootDir /workspace/Trading777)*

------
https://chatgpt.com/codex/tasks/task_e_689802f5ccf4832eb17e58914aa90c23