### PR TITLE
Refactor win/loss metrics reporting

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-initial-positions.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-initial-positions.test.ts
@@ -50,7 +50,9 @@ describe("FIFO calculations with initial positions", () => {
     const metrics = calcMetrics(enriched, positions, [], initialPositions);
     expect(metrics.M4).toBe(250);
     expect(metrics.M5.fifo).toBe(20);
-    expect(metrics.M10.W).toBe(2);
-    expect(metrics.M10.L).toBe(0);
+    expect(metrics.M10.win).toBe(2);
+    expect(metrics.M10.loss).toBe(0);
+    expect(metrics.M10.flat).toBe(0);
+    expect(metrics.M10.rate).toBe(1);
   });
 });

--- a/apps/web/app/lib/__tests__/metrics-trades-json-historical.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-trades-json-historical.test.ts
@@ -51,8 +51,9 @@ describe('calcMetrics with trades.json historical lots', () => {
     expect(metrics.M7).toEqual({ B: 6, S: 8, P: 4, C: 4, total: 22 });
     expect(metrics.M8).toEqual({ B: 8, S: 8, P: 5, C: 4, total: 25 });
     expect(metrics.M9).toBe(0);
-    expect(metrics.M10.W).toBe(11);
-    expect(metrics.M10.L).toBe(2);
-    expect(metrics.M10.rate).toBeCloseTo(84.61538, 5);
+    expect(metrics.M10.win).toBe(11);
+    expect(metrics.M10.loss).toBe(2);
+    expect(metrics.M10.flat).toBe(0);
+    expect(metrics.M10.rate).toBeCloseTo(0.8461538, 5);
   });
 });

--- a/apps/web/app/lib/metrics-winloss.ts
+++ b/apps/web/app/lib/metrics-winloss.ts
@@ -1,0 +1,11 @@
+export function calcWinLossLots(closes: { pnl: number }[]) {
+  let win = 0, loss = 0, flat = 0;
+  for (const c of closes) {
+    if (c.pnl > 0) win++;
+    else if (c.pnl < 0) loss++;
+    else flat++;
+  }
+  const denom = win + loss;
+  const rate = denom ? win / denom : 0;
+  return { win, loss, flat, rate };
+}

--- a/apps/web/app/modules/DashboardMetrics.tsx
+++ b/apps/web/app/modules/DashboardMetrics.tsx
@@ -138,10 +138,11 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
         const m10 = value as Metrics["M10"];
         formattedValue = (
           <>
-            <span className="green">W/{m10.W}</span>{" "}
-            <span className="red">L/{m10.L}</span>{" "}
-            <span className={m10.rate >= 50 ? "green" : "red"}>
-              {m10.rate.toFixed(1)}%
+            <span className="green">W/{m10.win}</span>{" "}
+            <span className="red">L/{m10.loss}</span>{" "}
+            <span>F/{m10.flat}</span>{" "}
+            <span className={m10.rate >= 0.5 ? "green" : "red"}>
+              {(m10.rate * 100).toFixed(1)}%
             </span>
           </>
         );


### PR DESCRIPTION
## Summary
- add `calcWinLossLots` util for counting win/loss/flat trades
- expose win/loss/flat rate in metrics computation
- show detailed win/loss stats in dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68980b1b5ca8832e9cd059a073d23f73