### PR TITLE
test: enforce dailyResult schema

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -11,4 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: echo "CI running (no [skip ci] found)"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/apps/web/app/lib/__tests__/dailyResult-schema.test.ts
+++ b/apps/web/app/lib/__tests__/dailyResult-schema.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+describe("dailyResult.json records", () => {
+  it("include exactly date, realized, and unrealized", () => {
+    const file = path.join(__dirname, "../../../public/dailyResult.json");
+    const data = JSON.parse(readFileSync(file, "utf8"));
+    expect(Array.isArray(data)).toBe(true);
+    for (const record of data) {
+      expect(Object.keys(record).sort()).toEqual([
+        "date",
+        "realized",
+        "unrealized",
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add jest test validating dailyResult.json records only expose date, realized, and unrealized
- run `npm test` in GitHub workflow to catch legacy fields

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898260f58fc832eb366f0b975a9d8fa