### PR TITLE
Include initial positions in cumulative trade counts

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-m8.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m8.test.ts
@@ -1,0 +1,33 @@
+import { calcMetrics } from "@/lib/metrics";
+import type { EnrichedTrade, InitialPosition } from "@/lib/fifo";
+
+describe("M8 cumulative trade counts", () => {
+  it("includes initial positions in totals", () => {
+    const trades: EnrichedTrade[] = [
+      {
+        symbol: "AAA",
+        action: "buy",
+        price: 10,
+        quantity: 1,
+        date: "2024-01-01T09:30:00Z",
+      } as any,
+      {
+        symbol: "BBB",
+        action: "short",
+        price: 20,
+        quantity: 1,
+        date: "2024-01-01T10:30:00Z",
+      } as any,
+    ];
+
+    const initialPositions: InitialPosition[] = [
+      { symbol: "CCC", qty: 5, avgPrice: 15 },
+      { symbol: "DDD", qty: -3, avgPrice: 25 },
+      { symbol: "", qty: 2, avgPrice: 10 },
+      { symbol: "EEE", qty: NaN, avgPrice: 8 },
+    ];
+
+    const metrics = calcMetrics(trades, [], [], initialPositions);
+    expect(metrics.M8).toEqual({ B: 2, S: 0, P: 2, C: 0, total: 4 });
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -385,6 +385,7 @@ function calcCumulativeTradeCounts(
   }
 
   for (const pos of initialPositions) {
+    if (!pos.symbol || !isFinite(pos.qty)) continue;
     if (pos.qty > 0) B++;
     else if (pos.qty < 0) P++;
   }


### PR DESCRIPTION
## Summary
- Count initial long and short positions when computing cumulative trade counts
- Ignore initial positions lacking a symbol or finite quantity
- Add a unit test verifying M8 includes historical positions

## Testing
- `jest apps/web/app/lib/__tests__/metrics-m8.test.ts` *(fails: Module ts-jest should have "jest-preset.js" or "jest-preset.json" file at the root)*

------
https://chatgpt.com/codex/tasks/task_e_68990a242a24832eb2fb5239e7fa64ab