### PR TITLE
Use daily results for period metrics and analysis

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-consistency.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-consistency.test.ts
@@ -1,5 +1,4 @@
-import { calcM9, collectCloseLots } from "@/lib/metrics";
-import { calcPeriodMetrics } from "@/lib/metrics-period";
+import { calcM9, collectCloseLots, calcWtdMtdYtd } from "@/lib/metrics";
 import { calcWinLossLots } from "@/lib/metrics-winloss";
 import type { DailyResult } from "@/lib/types";
 import { readFileSync } from "fs";
@@ -20,11 +19,11 @@ describe("metrics consistency", () => {
     });
   });
 
-  it("calcPeriodMetrics returns 8952.5 for single-day sample", () => {
+  it("calcWtdMtdYtd returns 8952.5 for single-day sample", () => {
     const days: DailyResult[] = [
       { date: "2025-08-01", realized: 7850, unrealized: 1102.5 },
     ];
-    const { wtd, mtd, ytd } = calcPeriodMetrics(days, "2025-08-01");
+    const { wtd, mtd, ytd } = calcWtdMtdYtd(days, "2025-08-01");
     expect(wtd).toBe(8952.5);
     expect(mtd).toBe(8952.5);
     expect(ytd).toBe(8952.5);

--- a/apps/web/app/lib/metrics-period.ts
+++ b/apps/web/app/lib/metrics-period.ts
@@ -1,23 +1,8 @@
 import type { DailyResult } from "./types";
-import { weekStartNY, monthStartNY, yearStartNY } from "./timezone";
+// Deprecated utilities retained for backward compatibility
 
 export function sumRealized(days: Pick<DailyResult, "realized">[]): number {
   return days.reduce((total, d) => total + d.realized, 0);
 }
 
-export function calcPeriodMetrics(
-  days: DailyResult[],
-  currentNyDate: string,
-): { wtd: number; mtd: number; ytd: number } {
-  const sum = (from: string) =>
-    days
-      .filter((r) => r.date >= from && r.date <= currentNyDate)
-      .reduce((acc, r) => acc + r.realized + r.unrealized, 0);
-
-  return {
-    wtd: sum(weekStartNY(currentNyDate)),
-    mtd: sum(monthStartNY(currentNyDate)),
-    ytd: sum(yearStartNY(currentNyDate)),
-  };
-}
 

--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -125,6 +125,31 @@ export const yearStartNY = (dateInput: string | Date): string => {
   return d.toISOString().slice(0, 10);
 };
 
+/** 获取纽约时区当周周一零点的 Date 对象 */
+export const startOfWeekNY = (dateInput: string | Date): Date => {
+  const d = toNY(dateInput);
+  const day = (d.getDay() + 6) % 7;
+  d.setDate(d.getDate() - day);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+/** 获取纽约时区当月月初零点的 Date 对象 */
+export const startOfMonthNY = (dateInput: string | Date): Date => {
+  const d = toNY(dateInput);
+  d.setDate(1);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+/** 获取纽约时区当年年初零点的 Date 对象 */
+export const startOfYearNY = (dateInput: string | Date): Date => {
+  const d = toNY(dateInput);
+  d.setMonth(0, 1);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
 // Attach helper to global for quick usage in dev tools
 // @ts-ignore
 (globalThis as any).toNY = toNY;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useMemo } from 'react';
-import { importData, findTrades, clearAllData, findPositions } from '@/lib/services/dataService';
+import { importData, findTrades, clearAllData, findPositions, loadDailyResults } from '@/lib/services/dataService';
 import { loadJson } from '@/app/lib/dataSource';
 import type { Trade, Position } from '@/lib/services/dataService';
 import { computeFifo, type InitialPosition } from '@/lib/fifo';
@@ -140,8 +140,7 @@ export default function DashboardPage() {
         })));
 
         // 获取每日结果数据用于计算周期性指标
-        const dailyResultsResponse = await fetch('/dailyResult.json');
-        const dailyResults = dailyResultsResponse.ok ? await dailyResultsResponse.json() : [];
+        const dailyResults = await loadDailyResults();
 
         // 计算指标并存入全局状态
         const initPos = dbPositions.map(({ symbol, qty, avgPrice }) => ({
@@ -234,8 +233,7 @@ export default function DashboardPage() {
       }
 
       // 获取每日结果数据用于计算周期性指标
-      const dailyResultsResponse = await fetch('/dailyResult.json');
-      const dailyResults = dailyResultsResponse.ok ? await dailyResultsResponse.json() : [];
+      const dailyResults = await loadDailyResults();
 
       // 计算指标并更新全局状态
       const initPos = dbPositions.map(({ symbol, qty, avgPrice }) => ({


### PR DESCRIPTION
## Summary
- add loadDailyResults with no-store caching and evaluation date helper
- compute WTD/MTD/YTD via realized+unrealized daily results and show on analysis page
- centralize daily result usage in dashboard and add NY boundary helpers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68991363fe1c832ea465c04e3578e29a