### PR TITLE
feat: add period debug to analysis page

### DIFF
--- a/apps/web/app/analysis/page.tsx
+++ b/apps/web/app/analysis/page.tsx
@@ -9,7 +9,7 @@ import { computeFifo, EnrichedTrade } from '@/lib/fifo';
 import { TradeCalendar } from '@/modules/TradeCalendar';
 import { RankingTable } from '@/modules/RankingTable';
 import { toNY } from '@/lib/timezone';
-import { calcWtdMtdYtd } from '@/lib/metrics';
+import { calcWtdMtdYtd, checkPeriodDebug } from '@/lib/metrics';
 
 declare const Chart: any;
 
@@ -34,6 +34,15 @@ export default function AnalysisPage() {
   const [period, setPeriod] = useState<'day' | 'week' | 'month'>('day');
   const pnlCanvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<any>(null);
+  const debugCalledRef = useRef(false);
+
+  useEffect(() => {
+    if (debugCalledRef.current || daily.length === 0) return;
+    if (process.env.NODE_ENV !== 'production') {
+      checkPeriodDebug(daily, evalDateStr);
+    }
+    debugCalledRef.current = true;
+  }, [daily, evalDateStr]);
 
   // 当 Chart.js 和每日结果数据准备好时绘制/更新图表
   useEffect(() => {

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -705,3 +705,11 @@ export function formatNumber(value: number, decimals: number = 2): string {
   if (isNaN(value)) return "N/A";
   return value.toFixed(decimals);
 }
+
+export function checkPeriodDebug(
+  daily: DailyResult[],
+  evalDateStr: string,
+): void {
+  const { wtd, mtd, ytd } = calcWtdMtdYtd(daily, evalDateStr);
+  console.debug("checkPeriodDebug", { wtd, mtd, ytd, evalDateStr });
+}


### PR DESCRIPTION
## Summary
- add `checkPeriodDebug` helper to metrics library
- run period debug once on analysis page load when data arrives

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689920e11780832ea5f72e2447fa86fa