### PR TITLE
chore: add CI build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Build (PR)
+on: pull_request
+
+jobs:
+  build:
+    name: Build (PR)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci --omit=dev
+      - run: npx --yes turbo run build --output-logs=stream


### PR DESCRIPTION
## Summary
- add Build (PR) GitHub Actions workflow to run Next.js build on pull requests

## Testing
- `npm test` (fails: jest: not found)
- attempted `npm ci` but process did not complete

------
https://chatgpt.com/codex/tasks/task_e_689931b01dd4832ea7e9c79d0fc113c7