### PR TITLE
chore: install turbo as dependency

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -16,4 +16,5 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+        # turbo is installed as a dependency to avoid interactive prompts
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "date-fns-tz": "^3.2.0"
+        "date-fns-tz": "^3.2.0",
+        "turbo": "^2.5.4"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -18,7 +19,6 @@
         "jest": "^30.0.5",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.0",
-        "turbo": "^2.5.4",
         "typescript": "5.8.3"
       },
       "engines": {
@@ -9892,7 +9892,6 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmmirror.com/turbo/-/turbo-2.5.4.tgz",
       "integrity": "sha512-kc8ZibdRcuWUG1pbYSBFWqmIjynlD8Lp7IB6U3vIzvOv9VG+6Sp8bzyeBWE3Oi8XV5KsQrznyRTBPvrf99E4mA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
@@ -9913,7 +9912,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9927,7 +9925,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9941,7 +9938,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9955,7 +9951,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9969,7 +9964,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9983,7 +9977,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "jest": "^30.0.5",
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.0",
-    "turbo": "^2.5.4",
     "typescript": "5.8.3"
   },
   "engines": {
@@ -27,6 +26,7 @@
     "packages/*"
   ],
   "dependencies": {
-    "date-fns-tz": "^3.2.0"
+    "date-fns-tz": "^3.2.0",
+    "turbo": "^2.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- avoid interactive prompts by installing turbo as a dependency
- note the dependency installation in the guard workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689931b01534832e9238d243bbc31523