### PR TITLE
chore: remove debug output from dashboard

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,7 @@ import { TradesTable } from '@/modules/TradesTable';
 import { SymbolTags } from '@/modules/SymbolTags';
 import AddTradeModal from '@/components/AddTradeModal';
 import Link from 'next/link';
-import { calcMetrics, debugTodayRealizedBreakdown } from '@/lib/metrics';
+import { calcMetrics } from '@/lib/metrics';
 import { useStore } from '@/lib/store';
 import { fetchRealtimeQuote, fetchDailyClose } from '@/lib/services/priceService';
 import { getLatestTradingDayStr } from '@/lib/timezone';
@@ -131,14 +131,6 @@ export default function DashboardPage() {
           return;
         }
 
-        console.log('加载的持仓数据:', posList);
-        console.log('持仓数据中的qty类型:', posList.map(p => ({
-          symbol: p.symbol,
-          qty: p.qty,
-          qtyType: typeof p.qty,
-          isNumber: !isNaN(Number(p.qty))
-        })));
-
         // 获取每日结果数据用于计算周期性指标
         const dailyResults = await loadDailyResults();
 
@@ -150,13 +142,6 @@ export default function DashboardPage() {
         }));
         const metrics = calcMetrics(enriched, posList, dailyResults, initPos);
         useStore.getState().setMetrics(metrics);
-
-        if (process.env.NODE_ENV !== 'production') {
-          const dbg = debugTodayRealizedBreakdown();
-          console.table(dbg.rows.slice(0, 8));
-          console.log('M4 sum =', dbg.sumM4, '(expected 6530)');
-          console.log('M5.2 sum =', dbg.sumM52, '(expected 1320)');
-        }
 
         setTrades(dbTrades);
         setPositions(posList);
@@ -250,13 +235,6 @@ export default function DashboardPage() {
       }));
       const metrics = calcMetrics(enriched, posList, dailyResults, initPos);
       useStore.getState().setMetrics(metrics);
-
-      if (process.env.NODE_ENV !== 'production') {
-        const dbg = debugTodayRealizedBreakdown();
-        console.table(dbg.rows.slice(0, 8));
-        console.log('M4 sum =', dbg.sumM4, '(expected 6530)');
-        console.log('M5.2 sum =', dbg.sumM52, '(expected 1320)');
-      }
 
       setTrades(dbTrades);
       setPositions(posList);


### PR DESCRIPTION
## Summary
- remove debug-related import and console logs from dashboard
- drop debugTodayRealizedBreakdown and associated dev logging

## Testing
- `npm run lint` *(fails: turbo: not found)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689931266528832ebb71ec81d2e9ccac