### PR TITLE
feat: add metrics debug table for analysis

### DIFF
--- a/apps/web/app/analysis/AnalysisDebugTable.tsx
+++ b/apps/web/app/analysis/AnalysisDebugTable.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useStore } from '@/lib/store';
+
+export default function AnalysisDebugTable() {
+  const metrics = useStore(state => state.metrics);
+  const logged = useRef(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    if (logged.current || !metrics) return;
+    console.table({
+      M1: metrics.M1,
+      M2: metrics.M2,
+      M3: metrics.M3,
+      M4: metrics.M4,
+      'M5.1': metrics.M5.trade,
+      'M5.2': metrics.M5.fifo,
+      M6: metrics.M6,
+      M7: `B/${metrics.M7.B} S/${metrics.M7.S} P/${metrics.M7.P} C/${metrics.M7.C}`,
+      M8: `B/${metrics.M8.B} S/${metrics.M8.S} P/${metrics.M8.P} C/${metrics.M8.C}`,
+      M9: metrics.M9,
+      M10: `W/${metrics.M10.win} L/${metrics.M10.loss} ${(metrics.M10.rate * 100).toFixed(1)}%`,
+      M11: metrics.M11,
+      M12: metrics.M12,
+      M13: metrics.M13,
+    });
+    logged.current = true;
+  }, [metrics]);
+
+  return null;
+}
+

--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -313,11 +313,8 @@ export async function findTrades(): Promise<Trade[]> {
     const trade = cursor.value as Trade;
     const id = cursor.key as number;
     list.push({ ...trade, id });
-    console.log("获取交易:", { ...trade, id });
     cursor = await cursor.continue();
   }
-
-  console.log(`总共获取到 ${list.length} 条交易记录`);
   return list;
 }
 


### PR DESCRIPTION
## Summary
- dynamically load AnalysisDebugTable and compute metrics on analysis page
- add client-side debug table to log metrics M1-M13 once
- remove extraneous console logging

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: turbo: not found)*
- `npm run check-types` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899441d75f0832ea5960976713581a1