### PR TITLE
fix: call dashboard metrics hooks unconditionally

### DIFF
--- a/apps/web/app/modules/DashboardMetrics.tsx
+++ b/apps/web/app/modules/DashboardMetrics.tsx
@@ -45,15 +45,6 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
   // 从全局状态获取指标
   const metrics = useStore((state) => state.metrics);
 
-  // 如果指标未加载，显示加载中
-  if (!metrics) {
-    return (
-      <section id="stats" className="stats-grid">
-        正在加载指标...
-      </section>
-    );
-  }
-
   // 定义指标名称映射
   const metricNames: Record<keyof Metrics, string> = useMemo(
     () => ({
@@ -96,6 +87,8 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
 
   // 格式化指标值并确定颜色
   const formattedMetrics = useMemo(() => {
+    if (!metrics) return [];
+
     return order.map((key) => {
       const value = metrics[key];
       let formattedValue: ReactNode;
@@ -168,6 +161,15 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
       };
     });
   }, [metrics, metricNames, order]);
+
+  // 如果指标未加载，显示加载中
+  if (!metrics) {
+    return (
+      <section id="stats" className="stats-grid">
+        正在加载指标...
+      </section>
+    );
+  }
 
   return (
     <section id="stats" className="my-5">


### PR DESCRIPTION
## Summary
- invoke useMemo hooks in `DashboardMetrics` on every render and handle missing metrics internally
- keep loading section for undefined metrics

## Testing
- `npm run lint --workspace=apps/web` *(fails: next not found)*
- `npm run build --workspace=apps/web` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bda72b2e0832eb4f9d372c1ba1049