### PR TITLE
refactor: remove any and ts-ignore usages

### DIFF
--- a/apps/web/app/lib/__tests__/calcTodayTradePnL.test.ts
+++ b/apps/web/app/lib/__tests__/calcTodayTradePnL.test.ts
@@ -4,8 +4,8 @@ import type { EnrichedTrade } from "@/lib/fifo";
 describe("calcTodayTradePnL sorting", () => {
   it("processes identical timestamps in original order", () => {
     const trades: EnrichedTrade[] = [
-      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
-      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
     ];
     const pnl = calcTodayTradePnL(trades, "2024-08-20");
     expect(pnl).toBe(0);
@@ -13,9 +13,9 @@ describe("calcTodayTradePnL sorting", () => {
 
   it("ignores malformed dates without throwing", () => {
     const trades: EnrichedTrade[] = [
-      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "bad-date" } as any,
-      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T09:00:00Z" } as any,
-      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "bad-date" } as unknown as EnrichedTrade,
+      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T09:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
     ];
     expect(() => calcTodayTradePnL(trades, "2024-08-20")).not.toThrow();
     const pnl = calcTodayTradePnL(trades, "2024-08-20");

--- a/apps/web/app/lib/__tests__/metrics-m8.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m8.test.ts
@@ -10,14 +10,14 @@ describe("M8 cumulative trade counts", () => {
         price: 10,
         quantity: 1,
         date: "2024-01-01T09:30:00Z",
-      } as any,
+      } as unknown as EnrichedTrade,
       {
         symbol: "BBB",
         action: "short",
         price: 20,
         quantity: 1,
         date: "2024-01-01T10:30:00Z",
-      } as any,
+      } as unknown as EnrichedTrade,
     ];
 
     const initialPositions: InitialPosition[] = [

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -14,6 +14,8 @@ import type { DailyResult } from "./types";
 import { sumRealized } from "./metrics-period";
 import { calcWinLossLots } from "./metrics-winloss";
 
+type TradeWithOptionalTime = EnrichedTrade & { time?: string };
+
 export function isDebug() {
   return (
     typeof window !== "undefined" &&
@@ -685,8 +687,8 @@ export function calcMetrics(
   const evalDateNY = nowNY();
   const todayStr = getLatestTradingDayStr(evalDateNY);
   const evalEnd = endOfDayNY(evalDateNY);
-  const safeTrades = trades.filter((t) => {
-    const d = toNY((t as any).time ?? t.date);
+  const safeTrades = trades.filter((t: TradeWithOptionalTime) => {
+    const d = toNY(t.time ?? t.date);
     return !isNaN(d.getTime()) && d.getTime() <= evalEnd.getTime();
   });
 

--- a/apps/web/app/lib/services/apiQueue.ts
+++ b/apps/web/app/lib/services/apiQueue.ts
@@ -12,11 +12,11 @@ export class ApiQueue {
   /** 等待执行的任务队列 */
   private queue: Array<{
     /** 要执行的异步函数 */
-    fn: () => Promise<any>;
+    fn: () => Promise<unknown>;
     /** 成功回调 */
-    resolve: (value: any) => void;
+    resolve: (value: unknown) => void;
     /** 失败回调 */
-    reject: (error?: any) => void;
+    reject: (error?: unknown) => void;
   }> = [];
 
   /** 令牌填充定时器 ID */

--- a/apps/web/app/lib/services/dataService.test.ts
+++ b/apps/web/app/lib/services/dataService.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import { openDB } from "idb";
-import { importData, clearAndImportData, closeDb } from "./dataService";
+import { importData, clearAndImportData, closeDb, type RawTrade, type Position } from "./dataService";
 import { createHash } from "crypto";
 
 describe("dataService trade import", () => {
@@ -13,8 +13,8 @@ describe("dataService trade import", () => {
   });
 
   test("importData skips malformed trades without aborting", async () => {
-    const rawData: any = {
-      positions: [],
+    const rawData = {
+      positions: [] as Position[],
       trades: [
         {
           date: "2025-01-01",
@@ -22,22 +22,22 @@ describe("dataService trade import", () => {
           side: "BUY",
           qty: 10,
           price: 100,
-        },
+        } as RawTrade,
         {
           date: "2025-01-02",
           symbol: "MSFT",
-          side: "INVALID" as any,
+          side: "INVALID" as unknown as RawTrade["side"],
           qty: 5,
           price: 200,
-        },
-        { date: "2025-01-03", symbol: "TSLA", qty: 3, price: 300 },
+        } as unknown as RawTrade,
+        { date: "2025-01-03", symbol: "TSLA", qty: 3, price: 300 } as unknown as RawTrade,
         {
           date: "2025-01-04",
           symbol: "GOOG",
           side: "SELL",
           qty: 2,
           price: 150,
-        },
+        } as RawTrade,
       ],
     };
 
@@ -49,23 +49,23 @@ describe("dataService trade import", () => {
   });
 
   test("clearAndImportData skips malformed trades", async () => {
-    const rawData: any = {
-      positions: [],
+    const rawData = {
+      positions: [] as Position[],
       trades: [
         {
           date: "2025-02-01",
           symbol: "MSFT",
-          side: "INVALID" as any,
+          side: "INVALID" as unknown as RawTrade["side"],
           qty: 1,
           price: 200,
-        },
+        } as unknown as RawTrade,
         {
           date: "2025-02-02",
           symbol: "GOOG",
           side: "SELL",
           qty: 1,
           price: 150,
-        },
+        } as RawTrade,
       ],
     };
 
@@ -115,7 +115,7 @@ describe("dataService trade import", () => {
     await clearAndImportData(rawData);
     expect(global.localStorage.getItem("dataset-hash")).toBe(expectedHash);
     // cleanup
-    // @ts-ignore
+    // @ts-expect-error: Remove mock localStorage used in tests
     delete global.localStorage;
   });
 

--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -323,25 +323,26 @@ export async function findPositions(): Promise<Position[]> {
   return db.getAll(POSITIONS_STORE_NAME);
 }
 
-const toNum = (v: any) => (Number.isFinite(+v) ? +v : 0);
+const toNum = (v: unknown) => (Number.isFinite(Number(v)) ? Number(v) : 0);
 
 export async function loadDailyResults(): Promise<DailyResult[]> {
   try {
     const res = await fetch("/dailyResult.json", { cache: "no-store" });
-    const raw = await res.json();
-    const arr: any[] = Array.isArray(raw)
+    const raw: unknown = await res.json();
+    const arr: unknown[] = Array.isArray(raw)
       ? raw
-      : Array.isArray(raw?.items)
-        ? raw.items
+      : Array.isArray((raw as { items?: unknown[] })?.items)
+        ? (raw as { items: unknown[] }).items
         : [];
     const map = new Map<string, DailyResult>();
     for (const x of arr) {
-      const d = String(x.date ?? "").slice(0, 10);
+      const item = x as Record<string, unknown>;
+      const d = String(item.date ?? "").slice(0, 10);
       if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) continue;
       map.set(d, {
         date: d,
-        realized: toNum(x.realized),
-        unrealized: toNum(x.unrealized),
+        realized: toNum(item.realized),
+        unrealized: toNum(item.unrealized),
       });
     }
     return [...map.values()].sort((a, b) => (a.date < b.date ? -1 : 1));

--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -17,6 +17,12 @@
 if (typeof process !== "undefined") {
   process.env.TZ = process.env.TZ || "America/New_York";
 }
+
+declare global {
+  interface Window {
+    NEXT_PUBLIC_FREEZE_DATE?: string;
+  }
+}
 export function toNY(): Date;
 export function toNY(value: string | number | Date): Date;
 export function toNY(
@@ -30,7 +36,9 @@ export function toNY(
 ): Date;
 
 /** 实现 – 同 Date 构造函数，但最终始终转换为纽约时间 */
-export function toNY(...args: any[]): Date {
+type DateConstructorArgs = ConstructorParameters<typeof Date>;
+
+export function toNY(...args: DateConstructorArgs): Date {
   let date: Date;
 
   if (args.length === 0) {
@@ -42,7 +50,7 @@ export function toNY(...args: any[]): Date {
     // 与 new Date(year, month, ...) 行为保持一致
     // (服务器已通过 TZ=America/New_York 保证本地时区为纽约，否则仍再转一次)
     // eslint-disable-next-line prefer-spread
-    date = new (Date as any)(...args);
+    date = new Date(...args);
   }
 
   // 若环境时区已经是纽约，则无需转换
@@ -82,8 +90,7 @@ export const formatNY = (
 export const getLatestTradingDayStr = (base: Date = nowNY()): string => {
   const freeze =
     (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_FREEZE_DATE) ||
-    // @ts-ignore
-    (typeof window !== 'undefined' && (window as any).NEXT_PUBLIC_FREEZE_DATE);
+    (typeof window !== 'undefined' && window.NEXT_PUBLIC_FREEZE_DATE);
   if (freeze) return freeze as string;
 
   const d = toNY(base);
@@ -150,10 +157,18 @@ export const startOfYearNY = (dateInput: string | Date): Date => {
   return d;
 };
 
-// Attach helper to global for quick usage in dev tools
-// @ts-ignore
-(globalThis as any).toNY = toNY;
-(globalThis as any).nowNY = nowNY;
-(globalThis as any).formatNY = formatNY;
-(globalThis as any).getLatestTradingDayStr = getLatestTradingDayStr;
-(globalThis as any).endOfDayNY = endOfDayNY;
+// Attach helpers to global for quick usage in dev tools
+interface TimezoneGlobal extends typeof globalThis {
+  toNY: typeof toNY;
+  nowNY: typeof nowNY;
+  formatNY: typeof formatNY;
+  getLatestTradingDayStr: typeof getLatestTradingDayStr;
+  endOfDayNY: typeof endOfDayNY;
+}
+
+const g = globalThis as TimezoneGlobal;
+g.toNY = toNY;
+g.nowNY = nowNY;
+g.formatNY = formatNY;
+g.getLatestTradingDayStr = getLatestTradingDayStr;
+g.endOfDayNY = endOfDayNY;

--- a/apps/web/app/modules/TradeCalendar.tsx
+++ b/apps/web/app/modules/TradeCalendar.tsx
@@ -39,8 +39,7 @@ export function TradeCalendar({ trades, title, id, isIntraday = false }: TradeCa
       const [year, mon, day] = d.date.split('-').map(Number);
       const key = `${year}-${String(mon).padStart(2, '0')}`;
       if (!byMonth[key]) byMonth[key] = [];
-      // @ts-ignore - ensure pnl is treated as number
-      byMonth[key].push({ day, pnl: (d.realized ?? 0) });
+      byMonth[key].push({ day, pnl: d.realized ?? 0 });
     });
     return byMonth;
   }, [dailyData]);


### PR DESCRIPTION
## Summary
- replace `any` and `@ts-ignore` with explicit types for timezone helpers and metrics
- tighten types for data loading and API queue helpers
- update tests with `@ts-expect-error` and precise trade casting

## Testing
- `npx --yes turbo run check-types` *(fails: Cannot find type definition file for 'yargs')*

------
https://chatgpt.com/codex/tasks/task_e_689bee1d211c832eb1ebaa4a94f5edab