### PR TITLE
chore: add env vars to turbo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
-  "globalEnv": ["FINNHUB_API_KEY"],
+  "globalEnv": ["NODE_ENV", "TZ", "FINNHUB_API_KEY"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- include `NODE_ENV` and `TZ` in Turborepo `globalEnv`

## Testing
- `npm run build` *(fails: turbo: not found)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf6252f44832e8134696c712bc87b