### PR TITLE
Expand Jest testMatch patterns

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,7 @@ import type { Config } from 'jest';
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.spec.ts'],
+  testMatch: ['**/tests/**/*.spec.ts', '**/app/lib/**/*.(test|spec).ts'],
   transform: { '^.+\\.ts$': ['ts-jest', {}] }
 };
 export default config;


### PR DESCRIPTION
## Summary
- broaden Jest's `testMatch` to include `app/lib` test files

## Testing
- `npm test` *(fails: Jest requires 'ts-node' for TypeScript config)*

------
https://chatgpt.com/codex/tasks/task_e_689c0131b28c832ebca0733292d7eaa6