### PR TITLE
fix irregular whitespace in timezone helper

### DIFF
--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -1,5 +1,5 @@
 /**
- * timezone.ts – Helpers to ensure the site consistently uses New York (America/New_York) time,
+ * timezone.ts – Helpers to ensure the site consistently uses New York (America/New_York) time,
  * regardless of server or browser locale.
  *
  * 统一处理纽约时区（America/New_York）工具函数：


### PR DESCRIPTION
## Summary
- replace non-breaking space with normal space in `timezone.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/Trading777/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_689c304ea478832ebb32145eb24fc892