### PR TITLE
Fix timezone helper globals to avoid build syntax errors

### DIFF
--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -157,16 +157,18 @@ export const startOfYearNY = (dateInput: string | Date): Date => {
   return d;
 };
 
-// Attach helpers to global for quick usage in dev tools
-interface TimezoneGlobal extends typeof globalThis {
+// Attach helpers to global for quick usage in dev tools. Using a plain
+// intersection type keeps the runtime code simple and avoids parser issues
+// when compiling with SWC.
+type TimezoneHelpers = {
   toNY: typeof toNY;
   nowNY: typeof nowNY;
   formatNY: typeof formatNY;
   getLatestTradingDayStr: typeof getLatestTradingDayStr;
   endOfDayNY: typeof endOfDayNY;
-}
+};
 
-const g = globalThis as TimezoneGlobal;
+const g = globalThis as typeof globalThis & TimezoneHelpers;
 g.toNY = toNY;
 g.nowNY = nowNY;
 g.formatNY = formatNY;


### PR DESCRIPTION
## Summary
- use intersection type when attaching timezone helpers to global object
- avoids SWC parse errors during Next.js build

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3510fe30832e973181553a4b3e6f