### PR TITLE
chore: remove timezone overload declarations

### DIFF
--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -23,16 +23,6 @@ declare global {
     NEXT_PUBLIC_FREEZE_DATE?: string;
   }
 }
-export function toNY(value?: string | number | Date): Date;
-export function toNY(
-  year: number,
-  month: number,
-  date?: number,
-  hours?: number,
-  minutes?: number,
-  seconds?: number,
-  ms?: number,
-): Date;
 
 /** 实现 – 同 Date 构造函数，但最终始终转换为纽约时间 */
 export function toNY(


### PR DESCRIPTION
## Summary
- remove redundant `toNY` overload declarations to rely on variadic implementation

## Testing
- `npm run build` *(fails: turbo: not found)*
- `npx tsc -p apps/web/tsconfig.json` *(fails: Cannot find type definition file for 'react')*

------
https://chatgpt.com/codex/tasks/task_e_689cbdbd55a0832eb74d9226cf7efe7e