### PR TITLE
refactor timezone to use Date tuple types

### DIFF
--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -24,9 +24,22 @@ declare global {
   }
 }
 
+type DateArgs =
+  | []
+  | [value: string | number | Date]
+  | [
+      year: number,
+      month: number,
+      date?: number,
+      hours?: number,
+      minutes?: number,
+      seconds?: number,
+      ms?: number,
+    ];
+
 /** 实现 – 同 Date 构造函数，但最终始终转换为纽约时间 */
 export function toNY(
-  ...args: ConstructorParameters<typeof Date>
+  ...args: DateArgs
 ): Date {
   let date: Date;
 


### PR DESCRIPTION
## Summary
- refactor `toNY` to use explicit Date constructor tuple types

## Testing
- `npm run build` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cea86dfac832e9610c344cf2111b6