### PR TITLE
feat: track unrealized delta in period metrics

### DIFF
--- a/apps/web/app/lib/__tests__/dailyResult-schema.test.ts
+++ b/apps/web/app/lib/__tests__/dailyResult-schema.test.ts
@@ -2,16 +2,22 @@ import { readFileSync } from "fs";
 import path from "path";
 
 describe("dailyResult.json records", () => {
-  it("include exactly date, realized, and unrealized", () => {
+  it("include required date, realized, unrealized and optional unrealizedDelta", () => {
     const file = path.join(__dirname, "../../../public/dailyResult.json");
     const data = JSON.parse(readFileSync(file, "utf8"));
     expect(Array.isArray(data)).toBe(true);
     for (const record of data) {
-      expect(Object.keys(record).sort()).toEqual([
-        "date",
-        "realized",
-        "unrealized",
-      ]);
+      const keys = Object.keys(record).sort();
+      if (keys.includes("unrealizedDelta")) {
+        expect(keys).toEqual([
+          "date",
+          "realized",
+          "unrealized",
+          "unrealizedDelta",
+        ]);
+      } else {
+        expect(keys).toEqual(["date", "realized", "unrealized"]);
+      }
     }
   });
 });

--- a/apps/web/app/lib/__tests__/metrics-wtd-mtd-ytd.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-wtd-mtd-ytd.test.ts
@@ -1,0 +1,14 @@
+import { calcWtdMtdYtd } from "@/lib/metrics";
+import type { DailyResult } from "@/lib/types";
+
+describe("calcWtdMtdYtd", () => {
+  it("sums realized and unrealized delta across days", () => {
+    const daily: DailyResult[] = [
+      { date: "2024-01-01", realized: 100, unrealized: 50, unrealizedDelta: 50 },
+      { date: "2024-01-02", realized: 0, unrealized: -20, unrealizedDelta: -70 },
+      { date: "2024-01-03", realized: 10, unrealized: 30, unrealizedDelta: 50 },
+    ];
+    const { wtd, mtd, ytd } = calcWtdMtdYtd(daily, "2024-01-03");
+    expect({ wtd, mtd, ytd }).toEqual({ wtd: 140, mtd: 140, ytd: 140 });
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -192,10 +192,23 @@ function sumPeriod(daily: DailyResult[], fromStr: string, toStr: string) {
   const fromTS = toNY(fromStr).getTime();
   const toTS = toNY(toStr).getTime();
   let total = 0;
-  for (const r of daily) {
+  let prevUnrealized = 0;
+
+  const sorted = daily.slice().sort((a, b) => (a.date < b.date ? -1 : 1));
+  for (const r of sorted) {
     const ts = toNY(r.date).getTime();
-    if (ts >= fromTS && ts <= toTS)
-      total += (r.realized ?? 0) + (r.unrealized ?? 0);
+    const unrealized = r.unrealized ?? 0;
+    if (ts < fromTS) {
+      prevUnrealized = unrealized;
+      continue;
+    }
+    if (ts > toTS) break;
+    const delta =
+      r.unrealizedDelta !== undefined
+        ? r.unrealizedDelta
+        : unrealized - prevUnrealized;
+    total += (r.realized ?? 0) + delta;
+    prevUnrealized = unrealized;
   }
   return total;
 }

--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -342,9 +342,21 @@ export async function loadDailyResults(): Promise<DailyResult[]> {
         date: d,
         realized: toNum(x.realized),
         unrealized: toNum(x.unrealized),
+        unrealizedDelta:
+          x.unrealizedDelta !== undefined
+            ? toNum(x.unrealizedDelta)
+            : undefined,
       });
     }
-    return [...map.values()].sort((a, b) => (a.date < b.date ? -1 : 1));
+    const list = [...map.values()].sort((a, b) => (a.date < b.date ? -1 : 1));
+    let prev = 0;
+    for (const r of list) {
+      if (r.unrealizedDelta === undefined) {
+        r.unrealizedDelta = (r.unrealized ?? 0) - prev;
+      }
+      prev = r.unrealized ?? 0;
+    }
+    return list;
   } catch (e) {
     console.warn("loadDailyResults failed", e);
     return [];

--- a/apps/web/app/lib/types.ts
+++ b/apps/web/app/lib/types.ts
@@ -2,4 +2,6 @@ export type DailyResult = {
   date: string;       // YYYY-MM-DD
   realized: number;   // M4 + M5.2
   unrealized: number; // M3
+  /** 每日浮盈变化量 */
+  unrealizedDelta?: number;
 };

--- a/apps/web/scripts/generateDailyResult.ts
+++ b/apps/web/scripts/generateDailyResult.ts
@@ -12,6 +12,7 @@ export function generateDailyResult(
   trades: EnrichedTrade[],
   positions: Position[],
   date: string,
+  prevUnrealized = 0,
 ): DailyResult {
   const realized = trades
     // Ensure trade has a valid date before checking prefix
@@ -32,5 +33,6 @@ export function generateDailyResult(
     date,
     realized,
     unrealized,
+    unrealizedDelta: unrealized - prevUnrealized,
   };
 }


### PR DESCRIPTION
## Summary
- compute period metrics from realized PnL plus daily unrealized changes
- persist unrealized deltas in `DailyResult` and generation/loading helpers
- test WTD/MTD/YTD calculations over multi-day unrealized swings

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d0bb5e65c832e93f705e63bd4cfc2