### PR TITLE
feat: validate trade dates in fifo metrics

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-fifo-date.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-fifo-date.test.ts
@@ -1,0 +1,34 @@
+import { calcTodayFifoPnL, calcHistoryFifoPnL } from "@/lib/metrics";
+import type { EnrichedTrade } from "@/lib/fifo";
+
+describe("FIFO date validation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("skips malformed and future dates for today's FIFO PnL", () => {
+    const trades: EnrichedTrade[] = [
+      { symbol: "AAPL", action: "buy", price: 90, quantity: 1, date: "2024-01-02T09:00:00Z" } as any,
+      { symbol: "AAPL", action: "sell", price: 110, quantity: 1, date: "2024-01-02T10:00:00Z" } as any,
+      { symbol: "AAPL", action: "buy", price: 100, quantity: 1, date: "bad-date" } as any,
+      { symbol: "AAPL", action: "sell", price: 120, quantity: 1, date: "2024-01-03T10:00:00Z" } as any,
+    ];
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const pnl = calcTodayFifoPnL(trades, "2024-01-02");
+    expect(pnl).toBe(20);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips malformed and future dates for historical FIFO PnL", () => {
+    const trades: EnrichedTrade[] = [
+      { symbol: "AAPL", action: "buy", price: 90, quantity: 1, date: "2024-01-01T10:00:00Z" } as any,
+      { symbol: "AAPL", action: "sell", price: 110, quantity: 1, date: "2024-01-02T10:00:00Z" } as any,
+      { symbol: "AAPL", action: "buy", price: 100, quantity: 1, date: "bad-date" } as any,
+      { symbol: "AAPL", action: "sell", price: 120, quantity: 1, date: "2024-01-03T10:00:00Z" } as any,
+    ];
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const pnl = calcHistoryFifoPnL(trades, "2024-01-02");
+    expect(pnl).toBe(20);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure calcTodayFifoPnL and calcHistoryFifoPnL skip malformed or future trade dates
- add unit tests covering invalid and future dates

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d210b986c832ea87b27846245a89d