### PR TITLE
test: cover DST transitions

### DIFF
--- a/apps/web/app/lib/__tests__/timezone.test.ts
+++ b/apps/web/app/lib/__tests__/timezone.test.ts
@@ -1,4 +1,4 @@
-import { getLatestTradingDayStr } from "../timezone";
+import { getLatestTradingDayStr, toNY } from "../timezone";
 
 describe("getLatestTradingDayStr", () => {
   it("returns previous Friday before market open on Monday", () => {
@@ -11,5 +11,17 @@ describe("getLatestTradingDayStr", () => {
     expect(getLatestTradingDayStr(new Date("2024-05-06T10:00:00-04:00"))).toBe(
       "2024-05-06",
     );
+  });
+});
+
+describe("DST transitions", () => {
+  it("handles daylight saving time start", () => {
+    const monday = toNY("2024-03-11T08:00:00");
+    expect(getLatestTradingDayStr(monday)).toBe("2024-03-08");
+  });
+
+  it("handles daylight saving time end", () => {
+    const monday = toNY("2024-11-04T08:00:00");
+    expect(getLatestTradingDayStr(monday)).toBe("2024-11-01");
   });
 });


### PR DESCRIPTION
## Summary
- add DST start and end test cases for `getLatestTradingDayStr`
- ensure `toNY` parses fixed inputs around daylight saving shifts

## Testing
- `npm test -- apps/web/app/lib/__tests__/timezone.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689d8c5ffe90832e98719db8b4b60384