### PR TITLE
feat: rebuild sumPeriod cache when data changes

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-sumPeriod-cache.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-sumPeriod-cache.test.ts
@@ -1,0 +1,20 @@
+import { sumPeriod } from "@/lib/metrics";
+import type { DailyResult } from "@/lib/types";
+
+describe("sumPeriod cache rebuild", () => {
+  it("rebuilds when the daily array is mutated", () => {
+    const daily: DailyResult[] = [
+      { date: "2024-01-01", realized: 1, unrealized: 0 },
+      { date: "2024-01-02", realized: 2, unrealized: 0 },
+    ];
+
+    // warm up cache
+    expect(sumPeriod(daily, "2024-01-01", "2024-01-02")).toBe(3);
+
+    // mutate original array
+    daily.push({ date: "2024-01-03", realized: 3, unrealized: 0 });
+
+    // expect cache to rebuild and include new record
+    expect(sumPeriod(daily, "2024-01-01", "2024-01-03")).toBe(6);
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -217,6 +217,10 @@ function isValidTradeDate(
 type SumPeriodCache = {
   /** 原始 daily 引用，用于判断是否需要重建缓存 */
   daily: DailyResult[];
+  /** 缓存时 daily 的长度 */
+  dailyLength: number;
+  /** 缓存时最后一条记录的日期 */
+  lastDate?: string;
   /** 按日期排序后的时间戳数组 */
   dates: number[];
   /** 累计收益前缀和 */
@@ -247,7 +251,13 @@ function rebuildSumPeriodCache(daily: DailyResult[]): SumPeriodCache {
     prefix.push(acc);
     prevUnrealized = unrealized;
   }
-  return { daily, dates, prefix };
+  return {
+    daily,
+    dailyLength: daily.length,
+    lastDate: daily[daily.length - 1]?.date,
+    dates,
+    prefix,
+  };
 }
 
 function lowerBound(arr: number[], target: number) {
@@ -277,7 +287,13 @@ export function sumPeriod(
   fromStr: string,
   toStr: string,
 ) {
-  if (!sumPeriodCache || sumPeriodCache.daily !== daily) {
+  const lastDate = daily[daily.length - 1]?.date;
+  if (
+    !sumPeriodCache ||
+    sumPeriodCache.daily !== daily ||
+    sumPeriodCache.dailyLength !== daily.length ||
+    sumPeriodCache.lastDate !== lastDate
+  ) {
     sumPeriodCache = rebuildSumPeriodCache(daily);
   } else if (
     sumPeriodCache.lastFrom === fromStr &&


### PR DESCRIPTION
## Summary
- track daily length and last date in sumPeriod cache and rebuild on change
- add unit test ensuring cache rebuilds after mutating daily array

## Testing
- `npm test` *(fails: jest: not found)*
- `npx -y jest apps/web/app/lib/__tests__/metrics-sumPeriod-cache.test.ts` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9fcfa8ec832e858b695b78585b05