### PR TITLE
fix: assert array indexing in binary search

### DIFF
--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -265,7 +265,8 @@ function lowerBound(arr: number[], target: number) {
     r = arr.length;
   while (l < r) {
     const m = (l + r) >> 1;
-    if (arr[m] < target) l = m + 1;
+    const midVal = arr[m]!;
+    if (midVal < target) l = m + 1;
     else r = m;
   }
   return l;
@@ -276,7 +277,8 @@ function upperBound(arr: number[], target: number) {
     r = arr.length;
   while (l < r) {
     const m = (l + r) >> 1;
-    if (arr[m] <= target) l = m + 1;
+    const midVal = arr[m]!;
+    if (midVal <= target) l = m + 1;
     else r = m;
   }
   return l - 1;


### PR DESCRIPTION
## Summary
- prevent TypeScript "possibly undefined" error by asserting binary search index accesses

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d083d2be8832e9740fdbdbefde323