### PR TITLE
Use npx for build and test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "trading-app",
   "private": true,
   "scripts": {
-    "build": "turbo run build",
-    "dev": "turbo run dev",
-    "lint": "turbo run lint",
+    "build": "npx --yes turbo run build",
+    "dev": "npx --yes turbo run dev",
+    "lint": "npx --yes turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "check-types": "turbo run check-types",
-    "test": "jest"
+    "check-types": "npx --yes turbo run check-types",
+    "test": "npx --yes jest"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary
- invoke turbo and jest via npx so scripts work even when local bins are missing

## Testing
- `npm test` *(fails: Preset ts-jest not found relative to rootDir /workspace/Trading777)*
- `npm run build` *(fails: command (/workspace/Trading777/apps/web) /root/.nvm/versions/node/v20.19.4/bin/npm run build exited (127))*

------
https://chatgpt.com/codex/tasks/task_e_689dc1565090832e864784ef2c74ff82