### PR TITLE
fix sumPeriod prefix bounds

### DIFF
--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -311,9 +311,9 @@ export function sumPeriod(
   const startIdx = lowerBound(dates, fromTS);
   const endIdx = upperBound(dates, toTS);
   let total = 0;
-  if (endIdx >= startIdx && endIdx >= 0) {
-    const prev = startIdx === 0 ? 0 : prefix[startIdx - 1];
-    total = prefix[endIdx] - prev;
+  if (endIdx >= startIdx && endIdx >= 0 && endIdx < prefix.length) {
+    const prev = startIdx === 0 ? 0 : prefix[startIdx - 1]!;
+    total = prefix[endIdx]! - prev;
   }
 
   sumPeriodCache.lastFrom = fromStr;


### PR DESCRIPTION
## Summary
- prevent out-of-range access in sumPeriod by validating prefix indices

## Testing
- `npx --yes turbo run build` *(fails: npm install ENOTEMPTY: directory not empty)*

------
https://chatgpt.com/codex/tasks/task_e_689de17bd650832eb91179ebec74477e