### PR TITLE
chore: expose node env vars to turborepo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
-  "globalEnv": ["FINNHUB_API_KEY"],
+  "globalEnv": ["FINNHUB_API_KEY", "NODE_ENV", "TZ"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- ensure NODE_ENV and TZ env vars are respected globally in turborepo tasks

## Testing
- `npm run lint` *(fails: Cannot find package '@repo/eslint-config' imported from packages/ui/eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_689de900b7c8832ea4c9d8d3f551fe12