### PR TITLE
refactor: move metrics hooks above early return

### DIFF
--- a/apps/web/app/modules/DashboardMetrics.tsx
+++ b/apps/web/app/modules/DashboardMetrics.tsx
@@ -45,15 +45,6 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
   // 从全局状态获取指标
   const metrics = useStore((state) => state.metrics);
 
-  // 如果指标未加载，显示加载中
-  if (!metrics) {
-    return (
-      <section id="stats" className="stats-grid">
-        正在加载指标...
-      </section>
-    );
-  }
-
   // 定义指标名称映射
   const metricNames: Record<keyof Metrics, string> = useMemo(
     () => ({
@@ -96,6 +87,7 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
 
   // 格式化指标值并确定颜色
   const formattedMetrics = useMemo(() => {
+    if (!metrics) return [];
     return order.map((key) => {
       const value = metrics[key];
       let formattedValue: ReactNode;
@@ -168,6 +160,10 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
       };
     });
   }, [metrics, metricNames, order]);
+
+  if (!metrics) {
+    return <section id="stats" className="stats-grid">正在加载指标...</section>;
+  }
 
   return (
     <section id="stats" className="my-5">


### PR DESCRIPTION
## Summary
- move metric memo hooks before early return
- render loading message after hook declarations

## Testing
- `npm -w web run lint app/modules/DashboardMetrics.tsx` *(fails: next not found)*
- `npx --yes eslint apps/web/app/modules/DashboardMetrics.tsx --no-config-lookup` *(fails: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_689e2a1c4254832ea07d77de5726c641