### PR TITLE
Use Next Image component for logos

### DIFF
--- a/apps/web/app/modules/PositionsTable.tsx
+++ b/apps/web/app/modules/PositionsTable.tsx
@@ -4,6 +4,7 @@ import { useQueries } from "@tanstack/react-query";
 import type { Position } from "@/lib/services/dataService";
 import { fetchRealtimeQuote } from "@/lib/services/priceService";
 import { useEffect, useState, useMemo } from "react";
+import Image from "next/image";
 import type { EnrichedTrade } from '@/lib/fifo';
 import { useStore } from '@/lib/store';
 import { formatCurrency } from '@/lib/metrics';
@@ -162,7 +163,15 @@ export function PositionsTable({ positions, trades }: Props) {
 
             return (
               <tr key={pos.symbol}>
-                <td><img className="logo" src={`/logos/${pos.symbol}.png`} alt={pos.symbol} /></td>
+                <td>
+                  <Image
+                    className="logo"
+                    src={`/logos/${pos.symbol}.png`}
+                    alt={pos.symbol}
+                    width={36}
+                    height={36}
+                  />
+                </td>
                 <td>{pos.symbol}</td>
                 <td>{nameMap[pos.symbol] || '--'}</td>
                 <td>

--- a/apps/web/app/modules/TradesTable.tsx
+++ b/apps/web/app/modules/TradesTable.tsx
@@ -2,6 +2,7 @@
 
 import type { EnrichedTrade } from "@/lib/fifo";
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import { toNY } from '@/lib/timezone';
 
 function formatNumber(value: number | undefined, decimals = 2) {
@@ -64,7 +65,15 @@ export function TradesTable({ trades }: { trades: EnrichedTrade[] }) {
             <tr key={idx}>
               <td>{trade.date}</td>
               <td>{weekday}</td>
-              <td><img className="logo" src={`/logos/${trade.symbol}.png`} alt={trade.symbol} /></td>
+              <td>
+                <Image
+                  className="logo"
+                  src={`/logos/${trade.symbol}.png`}
+                  alt={trade.symbol}
+                  width={36}
+                  height={36}
+                />
+              </td>
               <td>{trade.symbol}</td>
               <td className="cn">{nameMap[trade.symbol] || '--'}</td>
               <td className={colorSide}>{trade.action ? trade.action.toUpperCase() : 'UNKNOWN'}</td>

--- a/apps/web/app/stock/page.tsx
+++ b/apps/web/app/stock/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { findTrades } from '@/lib/services/dataService';
@@ -84,7 +85,14 @@ export default function StockPage() {
   return (
     <div>
       <div style={{ textAlign: 'center', marginTop: '20px' }}>
-        <img id="stock-logo" src={`/logos/${symbol}.png`} alt="Logo" style={{ height: '150px', objectFit: 'contain' }} />
+        <Image
+          id="stock-logo"
+          src={`/logos/${symbol}.png`}
+          alt="Logo"
+          width={150}
+          height={150}
+          style={{ height: '150px', objectFit: 'contain' }}
+        />
         <h2 className="section-title" id="title" style={{ marginTop: '10px' }}>
           {symbol}{zhName ? ` (${zhName})` : ''} 交易详情
         </h2>

--- a/apps/web/app/trades/page.tsx
+++ b/apps/web/app/trades/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import { findTrades, deleteTrade } from '@/lib/services/dataService';
 import { computeFifo, type EnrichedTrade } from '@/lib/fifo';
 import AddTradeModal from '@/components/AddTradeModal';
@@ -102,7 +103,15 @@ export default function TradesPage() {
             return (
               <tr key={idx}>
                 <td>{idx + 1}</td>
-                <td><img className="logo" src={`/logos/${trade.symbol}.png`} alt={trade.symbol} /></td>
+                <td>
+                  <Image
+                    className="logo"
+                    src={`/logos/${trade.symbol}.png`}
+                    alt={trade.symbol}
+                    width={36}
+                    height={36}
+                  />
+                </td>
                 <td>{trade.symbol}</td>
                 <td className="cn">{nameMap[trade.symbol] || '--'}</td>
                 <td>{trade.date}</td>


### PR DESCRIPTION
## Summary
- replace HTML `img` tags with Next.js `Image` in web tables and stock page
- import `next/image` in affected modules

## Testing
- `npm run lint --workspace=web` *(fails: sh: 1: next: not found)*
- `npm run build --workspace=web` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4b555acc832eb0dcfb8a63021a86