### PR TITLE
refactor: remove explicit any from web app

### DIFF
--- a/apps/web/app/analysis/page.tsx
+++ b/apps/web/app/analysis/page.tsx
@@ -17,7 +17,12 @@ import { useStore } from '@/lib/store';
 
 const AnalysisDebugTable = dynamic(() => import('./AnalysisDebugTable'), { ssr: false });
 
-declare const Chart: any;
+interface ChartInstance {
+  data: { labels: string[]; datasets: Array<{ data: number[] }> };
+  update: () => void;
+}
+type ChartCtor = new (ctx: CanvasRenderingContext2D, config: unknown) => ChartInstance;
+declare const Chart: ChartCtor;
 
 export default function AnalysisPage() {
   const [isChartReady, setIsChartReady] = useState(false);
@@ -41,7 +46,7 @@ export default function AnalysisPage() {
   const { wtd, mtd, ytd } = calcWtdMtdYtd(daily, evalDateStr);
   const [period, setPeriod] = useState<'day' | 'week' | 'month'>('day');
   const pnlCanvasRef = useRef<HTMLCanvasElement>(null);
-  const chartRef = useRef<any>(null);
+  const chartRef = useRef<ChartInstance | null>(null);
   const metricsLoadedRef = useRef(false);
 
   useEffect(() => {

--- a/apps/web/app/api/close-price/route.ts
+++ b/apps/web/app/api/close-price/route.ts
@@ -10,10 +10,10 @@ export async function POST(req: NextRequest) {
     if (!symbol || !date || typeof close !== 'number') {
       return new Response(JSON.stringify({ error: 'symbol,date,close required' }), { status: 400 });
     }
-    let data: any = {};
+    let data: Record<string, Record<string, number>> = {};
     try {
       const txt = await fs.readFile(FILE_PATH, 'utf8');
-      data = JSON.parse(txt || '{}');
+      data = JSON.parse(txt || '{}') as Record<string, Record<string, number>>;
     } catch {}
     if (!data[date]) data[date] = {};
     data[date][symbol] = close;

--- a/apps/web/app/components/AddTradeModal.tsx
+++ b/apps/web/app/components/AddTradeModal.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useEffect } from 'react';
 import { addTrade, updateTrade } from '@/lib/services/dataService';
+import type { Trade } from '@/lib/services/dataService';
 import { nowNY, toNY } from '@/lib/timezone';
 
 interface Props {
   onClose: () => void;
   onAdded: () => void;
-  trade?: any; // Assuming trade object structure
+  trade?: Trade;
 }
 
 function buildOptionSymbol(root: string, dateStr: string, cp: string, strike: number): string {

--- a/apps/web/app/lib/__tests__/calcTodayTradePnL.test.ts
+++ b/apps/web/app/lib/__tests__/calcTodayTradePnL.test.ts
@@ -4,8 +4,8 @@ import type { EnrichedTrade } from "@/lib/fifo";
 describe("calcTodayTradePnL sorting", () => {
   it("processes identical timestamps in original order", () => {
     const trades: EnrichedTrade[] = [
-      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
-      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
     ];
     const pnl = calcTodayTradePnL(trades, "2024-08-20");
     expect(pnl).toBe(0);
@@ -13,9 +13,9 @@ describe("calcTodayTradePnL sorting", () => {
 
   it("ignores malformed dates without throwing", () => {
     const trades: EnrichedTrade[] = [
-      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "bad-date" } as any,
-      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T09:00:00Z" } as any,
-      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as any,
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "bad-date" } as unknown as EnrichedTrade,
+      { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T09:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
     ];
     expect(() => calcTodayTradePnL(trades, "2024-08-20")).not.toThrow();
     const pnl = calcTodayTradePnL(trades, "2024-08-20");

--- a/apps/web/app/lib/__tests__/metrics-fifo-date.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-fifo-date.test.ts
@@ -8,10 +8,10 @@ describe("FIFO date validation", () => {
 
   it("skips malformed and future dates for today's FIFO PnL", () => {
     const trades: EnrichedTrade[] = [
-      { symbol: "AAPL", action: "buy", price: 90, quantity: 1, date: "2024-01-02T09:00:00Z" } as any,
-      { symbol: "AAPL", action: "sell", price: 110, quantity: 1, date: "2024-01-02T10:00:00Z" } as any,
-      { symbol: "AAPL", action: "buy", price: 100, quantity: 1, date: "bad-date" } as any,
-      { symbol: "AAPL", action: "sell", price: 120, quantity: 1, date: "2024-01-03T10:00:00Z" } as any,
+      { symbol: "AAPL", action: "buy", price: 90, quantity: 1, date: "2024-01-02T09:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "sell", price: 110, quantity: 1, date: "2024-01-02T10:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "buy", price: 100, quantity: 1, date: "bad-date" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "sell", price: 120, quantity: 1, date: "2024-01-03T10:00:00Z" } as unknown as EnrichedTrade,
     ];
     const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     const pnl = calcTodayFifoPnL(trades, "2024-01-02");
@@ -21,10 +21,10 @@ describe("FIFO date validation", () => {
 
   it("skips malformed and future dates for historical FIFO PnL", () => {
     const trades: EnrichedTrade[] = [
-      { symbol: "AAPL", action: "buy", price: 90, quantity: 1, date: "2024-01-01T10:00:00Z" } as any,
-      { symbol: "AAPL", action: "sell", price: 110, quantity: 1, date: "2024-01-02T10:00:00Z" } as any,
-      { symbol: "AAPL", action: "buy", price: 100, quantity: 1, date: "bad-date" } as any,
-      { symbol: "AAPL", action: "sell", price: 120, quantity: 1, date: "2024-01-03T10:00:00Z" } as any,
+      { symbol: "AAPL", action: "buy", price: 90, quantity: 1, date: "2024-01-01T10:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "sell", price: 110, quantity: 1, date: "2024-01-02T10:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "buy", price: 100, quantity: 1, date: "bad-date" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "sell", price: 120, quantity: 1, date: "2024-01-03T10:00:00Z" } as unknown as EnrichedTrade,
     ];
     const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     const pnl = calcHistoryFifoPnL(trades, "2024-01-02");

--- a/apps/web/app/lib/__tests__/metrics-m8.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-m8.test.ts
@@ -10,14 +10,14 @@ describe("M8 cumulative trade counts", () => {
         price: 10,
         quantity: 1,
         date: "2024-01-01T09:30:00Z",
-      } as any,
+      } as unknown as EnrichedTrade,
       {
         symbol: "BBB",
         action: "short",
         price: 20,
         quantity: 1,
         date: "2024-01-01T10:30:00Z",
-      } as any,
+      } as unknown as EnrichedTrade,
     ];
 
     const initialPositions: InitialPosition[] = [

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -813,7 +813,7 @@ export function calcMetrics(
   const todayStr = getLatestTradingDayStr(evalDateNY);
   const evalEnd = endOfDayNY(evalDateNY);
   const safeTrades = trades.filter((t) => {
-    const d = toNY((t as any).time ?? t.date);
+    const d = toNY(t.time ?? t.date);
     return !isNaN(d.getTime()) && d.getTime() <= evalEnd.getTime();
   });
 

--- a/apps/web/app/lib/services/apiQueue.ts
+++ b/apps/web/app/lib/services/apiQueue.ts
@@ -12,11 +12,11 @@ export class ApiQueue {
   /** 等待执行的任务队列 */
   private queue: Array<{
     /** 要执行的异步函数 */
-    fn: () => Promise<any>;
+    fn: () => Promise<unknown>;
     /** 成功回调 */
-    resolve: (value: any) => void;
+    resolve: (value: unknown) => void;
     /** 失败回调 */
-    reject: (error?: any) => void;
+    reject: (error?: unknown) => void;
   }> = [];
 
   /** 令牌填充定时器 ID */
@@ -52,7 +52,11 @@ export class ApiQueue {
    */
   enqueue<T>(fn: () => Promise<T>): Promise<T> {
     return new Promise<T>((resolve, reject) => {
-      this.queue.push({ fn, resolve, reject });
+      this.queue.push({
+        fn: fn as () => Promise<unknown>,
+        resolve: resolve as (value: unknown) => void,
+        reject: reject as (error?: unknown) => void,
+      });
       this.process();
     });
   }

--- a/apps/web/app/lib/services/dataService.test.ts
+++ b/apps/web/app/lib/services/dataService.test.ts
@@ -1,6 +1,7 @@
 import "fake-indexeddb/auto";
 import { openDB } from "idb";
 import { importData, clearAndImportData, closeDb } from "./dataService";
+import type { RawTrade, Position } from "./dataService";
 import { createHash } from "crypto";
 
 describe("dataService trade import", () => {
@@ -13,7 +14,7 @@ describe("dataService trade import", () => {
   });
 
   test("importData skips malformed trades without aborting", async () => {
-    const rawData: any = {
+    const rawData: { positions: Position[]; trades: RawTrade[] } = {
       positions: [],
       trades: [
         {
@@ -26,11 +27,11 @@ describe("dataService trade import", () => {
         {
           date: "2025-01-02",
           symbol: "MSFT",
-          side: "INVALID" as any,
+          side: "INVALID" as unknown as RawTrade["side"],
           qty: 5,
           price: 200,
         },
-        { date: "2025-01-03", symbol: "TSLA", qty: 3, price: 300 },
+        { date: "2025-01-03", symbol: "TSLA", qty: 3, price: 300 } as unknown as RawTrade,
         {
           date: "2025-01-04",
           symbol: "GOOG",
@@ -49,13 +50,13 @@ describe("dataService trade import", () => {
   });
 
   test("clearAndImportData skips malformed trades", async () => {
-    const rawData: any = {
+    const rawData: { positions: Position[]; trades: RawTrade[] } = {
       positions: [],
       trades: [
         {
           date: "2025-02-01",
           symbol: "MSFT",
-          side: "INVALID" as any,
+          side: "INVALID" as unknown as RawTrade["side"],
           qty: 1,
           price: 200,
         },


### PR DESCRIPTION
## Summary
- replace `any` with explicit interfaces and generics across web app
- tighten Date helpers and API queue typing to leverage `unknown`
- ensure components and tests use concrete types instead of `any`

## Testing
- `npm run lint` *(fails: @repo/ui#lint missing module)*

------
https://chatgpt.com/codex/tasks/task_e_689f770e7eac832e86cb2d1ae6d3669f