### PR TITLE
fix: handle chart dataset update safely

### DIFF
--- a/apps/web/app/analysis/page.tsx
+++ b/apps/web/app/analysis/page.tsx
@@ -118,7 +118,10 @@ export default function AnalysisPage() {
 
     if (chartRef.current) {
       chartRef.current.data.labels = dates;
-      chartRef.current.data.datasets[0].data = lineValues;
+      const dataset = chartRef.current.data.datasets[0];
+      if (dataset) {
+        dataset.data = lineValues;
+      }
       chartRef.current.update();
     } else {
       chartRef.current = new Chart(ctx, {


### PR DESCRIPTION
## Summary
- guard chart dataset assignment in analysis page to avoid undefined access

## Testing
- `npm test` *(fails: Preset ts-jest not found)*
- `npm --workspace apps/web run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6fb9ba0832e810934e740cdf17d