### PR TITLE
fix: handle chart dataset update safely and align timezone overloads

### DIFF
--- a/apps/web/app/analysis/page.tsx
+++ b/apps/web/app/analysis/page.tsx
@@ -118,7 +118,10 @@ export default function AnalysisPage() {
 
     if (chartRef.current) {
       chartRef.current.data.labels = dates;
-      chartRef.current.data.datasets[0].data = lineValues;
+      const dataset = chartRef.current.data.datasets[0];
+      if (dataset) {
+        dataset.data = lineValues;
+      }
       chartRef.current.update();
     } else {
       chartRef.current = new Chart(ctx, {

--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -29,8 +29,13 @@ export function toNY(
   ms?: number,
 ): Date;
 
+type ToNYArgs =
+  | []
+  | [string | number | Date]
+  | [number, number, number?, number?, number?, number?, number?];
+
 /** 实现 – 同 Date 构造函数，但最终始终转换为纽约时间 */
-export function toNY(...args: ConstructorParameters<typeof Date>): Date {
+export function toNY(...args: ToNYArgs): Date {
   let date: Date;
 
   if (args.length === 0) {


### PR DESCRIPTION
## Summary
- guard chart dataset assignment in analysis page to avoid undefined access
- align timezone helper overloads with implementation to satisfy TypeScript

## Testing
- `npm test` *(fails: Preset ts-jest not found)*
- `npm --workspace apps/web run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6fb9ba0832e810934e740cdf17d