### PR TITLE
chore: configure ts-jest for ESM

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,13 @@
 /** @type {import('jest').Config} */
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/apps/web/app/$1',
   },
@@ -11,4 +17,4 @@ module.exports = {
       tsconfig: 'apps/web/tsconfig.json',
     }],
   },
-}; 
+};


### PR DESCRIPTION
## Summary
- enable ESM support for Jest by using `ts-jest/presets/default-esm`
- configure `ts-jest` globals and ESM extensions

## Testing
- `npm test` *(fails: Preset ts-jest/presets/default-esm not found relative to rootDir)*

------
https://chatgpt.com/codex/tasks/task_e_689fb4e0e8ac832e935d8d1c87985e8a