### PR TITLE
Check price tokens before fetching data

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,6 +16,15 @@ malformed or empty dates.
 
 Copy the repository root `env.example` file to `.env` and fill in the required API keys before running the application.
 
+### Environment Variables
+
+The price services expect the following variables to be defined in `.env` or your Vercel project settings:
+
+- `NEXT_PUBLIC_FINNHUB_TOKEN` – Finnhub API token
+- `NEXT_PUBLIC_TIINGO_TOKEN` – Tiingo API token
+
+If these tokens are missing, external price lookups are skipped to prevent build and deployment failures.
+
 First, run the development server:
 
 ```bash

--- a/apps/web/app/lib/services/priceService.ts
+++ b/apps/web/app/lib/services/priceService.ts
@@ -91,6 +91,9 @@ async function fetchFinnhubDailyClose(symbol: string, date: string): Promise<num
 
 /** Finnhub: 实时报价 */
 async function fetchFinnhubRealtimeQuote(symbol: string): Promise<number | null> {
+  const token = await getFinnhubToken();
+  if (!token) { console.warn('未设置 Finnhub 令牌'); return null; }
+
   const url = `/api/quote?symbol=${encodeURIComponent(symbol)}`;
   try {
     const response = await apiQueue.enqueue(() => fetch(url));


### PR DESCRIPTION
## Summary
- guard Finnhub real-time fetches when API token is missing
- document required Finnhub and Tiingo tokens in web README

## Testing
- `npm test` *(fails: Preset ts-jest not found)*
- `npm run lint` *(fails: Cannot find package '@repo/eslint-config')*

------
https://chatgpt.com/codex/tasks/task_e_689fb5027a64832e832bdd5e0ebd0522