### PR TITLE
Fix toNY overload implementation

### DIFF
--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -1,5 +1,5 @@
 /**
- * timezone.ts – Helpers to ensure the site consistently uses New York (America/New_York) time,
+ * timezone.ts – Helpers to ensure the site consistently uses New York (America/New_York) time,
  * regardless of server or browser locale.
  *
  * 统一处理纽约时区（America/New_York）工具函数：
@@ -17,6 +17,12 @@
 if (typeof process !== "undefined") {
   process.env.TZ = process.env.TZ || "America/New_York";
 }
+
+type ToNYArgs =
+  | []
+  | [string | number | Date]
+  | [number, number, number?, number?, number?, number?, number?];
+
 export function toNY(): Date;
 export function toNY(value: string | number | Date): Date;
 export function toNY(
@@ -28,11 +34,6 @@ export function toNY(
   seconds?: number,
   ms?: number,
 ): Date;
-
-type ToNYArgs =
-  | []
-  | [string | number | Date]
-  | [number, number, number?, number?, number?, number?, number?];
 
 /** 实现 – 同 Date 构造函数，但最终始终转换为纽约时间 */
 export function toNY(...args: ToNYArgs): Date {


### PR DESCRIPTION
## Summary
- ensure overloaded `toNY` declarations are immediately followed by an implementation
- remove non-ASCII whitespace from `timezone.ts`

## Testing
- `npm test` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb88e0c6c832eafd8ce6e00da2fde