### PR TITLE
chore(ui): declare build outputs for turbo

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,9 @@
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
+  "turbo": {
+    "outputs": ["dist/**"]
+  },
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",


### PR DESCRIPTION
## Summary
- declare `dist/**` as Turbo build output for the `@repo/ui` package

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'istanbul-reports', 'jest', 'node', 'react', 'react-dom', 'stack-utils', 'use-sync-external-store', 'yargs', 'yargs-parser')*

------
https://chatgpt.com/codex/tasks/task_e_68a0efcb2de4832eb854fbaf080a5743