### PR TITLE
fix: refine freeze date window access

### DIFF
--- a/apps/web/app/lib/timezone.ts
+++ b/apps/web/app/lib/timezone.ts
@@ -78,10 +78,9 @@ export const formatNY = (
  */
 export const getLatestTradingDayStr = (base: Date = nowNY()): string => {
   const freeze =
-    (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_FREEZE_DATE) ||
-    // @ts-ignore
-    (typeof window !== 'undefined' &&
-      (window as Record<string, unknown>).NEXT_PUBLIC_FREEZE_DATE);
+    (typeof process !== "undefined" && process.env.NEXT_PUBLIC_FREEZE_DATE) ||
+    (typeof window !== "undefined" &&
+      (window as unknown as Record<string, unknown>).NEXT_PUBLIC_FREEZE_DATE);
   if (freeze) return freeze as string;
 
   const d = toNY(base);


### PR DESCRIPTION
## Summary
- safely access NEXT_PUBLIC_FREEZE_DATE on the window object without ts-ignore

## Testing
- `npm run build` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f3df4f18832e8a0fa34a03e716c1