### PR TITLE
chore: tidy lint warnings

### DIFF
--- a/apps/web/app/api/close-price/route.ts
+++ b/apps/web/app/api/close-price/route.ts
@@ -14,7 +14,12 @@ export async function POST(req: NextRequest) {
     try {
       const txt = await fs.readFile(FILE_PATH, 'utf8');
       data = JSON.parse(txt || '{}') as Record<string, Record<string, number>>;
-    } catch {}
+    }
+    // 文件可能不存在或 JSON 无法解析，此处忽略以便初始化为空对象
+    // eslint-disable-next-line no-empty
+    catch (_err) {
+      // intentionally empty
+    }
     if (!data[date]) data[date] = {};
     data[date][symbol] = close;
     await fs.writeFile(FILE_PATH, JSON.stringify(data, null, 2), 'utf8');

--- a/apps/web/app/lib/services/dataService.test.ts
+++ b/apps/web/app/lib/services/dataService.test.ts
@@ -116,7 +116,7 @@ describe("dataService trade import", () => {
     await clearAndImportData(rawData);
     expect(global.localStorage.getItem("dataset-hash")).toBe(expectedHash);
     // cleanup
-    // @ts-ignore
+    // @ts-expect-error - cleanup mocked localStorage
     delete global.localStorage;
   });
 

--- a/apps/web/app/lib/services/priceService.ts
+++ b/apps/web/app/lib/services/priceService.ts
@@ -119,7 +119,9 @@ async function fetchTiingoRealtimeQuote(symbol: string): Promise<number | null> 
     if (cached && Date.now() - cached.ts < 5 * 60_000 && typeof cached.price === 'number') {
       return cached.price;
     }
-  } catch {}
+  } catch (_err) {
+    // 忽略 localStorage 访问或 JSON 解析错误
+  }
 
   const url = `https://api.tiingo.com/iex/?token=${token}&tickers=${encodeURIComponent(symbol)}`;
   try {
@@ -129,7 +131,11 @@ async function fetchTiingoRealtimeQuote(symbol: string): Promise<number | null> 
     const first = Array.isArray(json) && json.length ? json[0] : undefined;
     if (first && typeof first.last === 'number') {
       const price = first.last;
-      try { localStorage.setItem(cacheKey, JSON.stringify({ price, ts: Date.now() })); } catch {}
+      try {
+        localStorage.setItem(cacheKey, JSON.stringify({ price, ts: Date.now() }));
+      } catch (_err) {
+        // 忽略写入 localStorage 的错误
+      }
       return price;
     }
   } catch (err) {
@@ -150,7 +156,9 @@ async function fetchTiingoDailyClose(symbol: string, date: string): Promise<numb
     if (cached && Date.now() - cached.ts < 5 * 60_000 && typeof cached.price === 'number') {
       return cached.price;
     }
-  } catch {}
+  } catch (_err) {
+    // 忽略 localStorage 访问或 JSON 解析错误
+  }
 
   const url = `https://api.tiingo.com/tiingo/daily/${encodeURIComponent(symbol)}/prices?token=${token}&startDate=${date}&endDate=${date}`;
   try {
@@ -160,7 +168,11 @@ async function fetchTiingoDailyClose(symbol: string, date: string): Promise<numb
     const first = Array.isArray(json) && json.length ? json[0] : undefined;
     if (first && typeof first.close === 'number') {
       const price = first.close;
-      try { localStorage.setItem(cacheKey, JSON.stringify({ price, ts: Date.now() })); } catch {}
+      try {
+        localStorage.setItem(cacheKey, JSON.stringify({ price, ts: Date.now() }));
+      } catch (_err) {
+        // 忽略写入 localStorage 的错误
+      }
       await putPrice({ symbol, date, close: price, source: 'tiingo' });
       return price;
     }

--- a/apps/web/app/modules/TradeCalendar.tsx
+++ b/apps/web/app/modules/TradeCalendar.tsx
@@ -39,7 +39,7 @@ export function TradeCalendar({ trades, title, id, isIntraday = false }: TradeCa
       const [year, mon, day] = d.date.split('-').map(Number);
       const key = `${year}-${String(mon).padStart(2, '0')}`;
       if (!byMonth[key]) byMonth[key] = [];
-      // @ts-ignore - ensure pnl is treated as number
+      // @ts-expect-error - ensure pnl is treated as number
       byMonth[key].push({ day, pnl: (d.realized ?? 0) });
     });
     return byMonth;


### PR DESCRIPTION
## Summary
- clarify ignored file read in close-price route
- guard Tiingo localStorage operations in price service
- replace `@ts-ignore` with `@ts-expect-error` where appropriate

## Testing
- `npm run lint` *(fails: next not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68a0fb606488832ebd3e550e3317c0e4