### PR TITLE
refactor: replace console logs with logger

### DIFF
--- a/apps/web/app/components/AddTradeModal.tsx
+++ b/apps/web/app/components/AddTradeModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { addTrade, updateTrade } from '@/lib/services/dataService';
 import type { Trade } from '@/lib/services/dataService';
 import { nowNY, toNY } from '@/lib/timezone';
+import { logger } from '@/lib/logger';
 
 interface Props {
   onClose: () => void;
@@ -57,7 +58,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
   // ---------- 同步传入的 trade 数据 ----------
   useEffect(() => {
     if (trade) {
-      console.log('[AddTradeModal] 编辑模式载入:', trade);
+      logger.debug('[AddTradeModal] 编辑模式载入:', trade);
       setSymbol(trade.symbol);
       if (!trade.action) {
         console.warn('Editing trade has invalid action, defaulting to BUY.');
@@ -114,10 +115,10 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
     };
 
     if (editing && trade?.id != null) {
-      console.log('[AddTradeModal] 更新交易:', { ...baseTrade, id: trade.id });
+      logger.debug('[AddTradeModal] 更新交易:', { ...baseTrade, id: trade.id });
       await updateTrade({ ...baseTrade, id: trade.id });
     } else {
-      console.log('[AddTradeModal] 新增交易:', baseTrade);
+      logger.debug('[AddTradeModal] 新增交易:', baseTrade);
       await addTrade(baseTrade);
     }
 

--- a/apps/web/app/lib/__tests__/metrics-sumPeriod-benchmark.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-sumPeriod-benchmark.test.ts
@@ -1,6 +1,7 @@
 import { performance } from "perf_hooks";
 import { sumPeriod } from "@/lib/metrics";
 import type { DailyResult } from "@/lib/types";
+import { logger } from "@/lib/logger";
 
 function generateDaily(count: number): DailyResult[] {
   const start = new Date("2000-01-01T00:00:00Z");
@@ -72,7 +73,7 @@ describe("sumPeriod benchmark", () => {
     const cachedTime = performance.now() - t2;
 
     // 输出用于观察
-    console.log("naive:", naiveTime, "cached:", cachedTime);
+    logger.info("naive:", naiveTime, "cached:", cachedTime);
 
     expect(cachedTime).toBeLessThan(naiveTime);
   });

--- a/apps/web/app/lib/logger.ts
+++ b/apps/web/app/lib/logger.ts
@@ -1,0 +1,30 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const levels: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const envLevel =
+  (typeof process !== 'undefined' && (process.env.LOG_LEVEL as LogLevel)) || 'info';
+const currentLevel = levels[envLevel] ?? levels.info;
+
+function log(level: LogLevel, ...args: unknown[]) {
+  if (levels[level] < currentLevel) return;
+  if (level === 'warn') {
+    console.warn(...args);
+  } else if (level === 'error') {
+    console.error(...args);
+  } else {
+    console.log(...args);
+  }
+}
+
+export const logger = {
+  debug: (...args: unknown[]) => log('debug', ...args),
+  info: (...args: unknown[]) => log('info', ...args),
+  warn: (...args: unknown[]) => log('warn', ...args),
+  error: (...args: unknown[]) => log('error', ...args),
+};

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -13,6 +13,7 @@ import { calcTodayTradePnL } from "./calcTodayTradePnL";
 import type { DailyResult } from "./types";
 import { sumRealized } from "./metrics-period";
 import { calcWinLossLots } from "./metrics-winloss";
+import { logger } from "@/lib/logger";
 
 export function isDebug() {
   return (
@@ -804,7 +805,7 @@ export function calcMetrics(
   initialPositions: InitialPosition[] = [],
 ): Metrics {
   if (DEBUG)
-    console.info("M7_INPUT", _count(trades), {
+    logger.debug("M7_INPUT", _count(trades), {
       sample: trades.slice(0, 3),
     });
 
@@ -818,7 +819,7 @@ export function calcMetrics(
   });
 
   if (DEBUG)
-    console.info("M7_FILTERED", _count(safeTrades), {
+    logger.debug("M7_FILTERED", _count(safeTrades), {
       evalEndNY: evalEnd.toISOString?.(),
     });
 
@@ -864,7 +865,7 @@ export function calcMetrics(
   );
 
   if (DEBUG)
-    console.info("M6_DEBUG", {
+    logger.debug("M6_DEBUG", {
       M4: todayHistoricalRealizedPnl,
       M3: floatPnl,
       fifo: pnlFifo,

--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -1,5 +1,6 @@
 import { openDB, DBSchema, IDBPDatabase } from "idb";
 import type { DailyResult } from "@/lib/types";
+import { logger } from "@/lib/logger";
 
 const DB_NAME = "TradingApp";
 const DB_VERSION = 3; // Incremented version for schema change
@@ -144,13 +145,13 @@ export async function importData(rawData: {
       /* ignore */
     }
   } else {
-    console.log("Dataset unchanged. Skipping import.");
+    logger.info("Dataset unchanged. Skipping import.");
     return;
   }
 
   const db = await getDb();
 
-  console.log("Importing data...");
+  logger.info("Importing data...");
   const tx = db.transaction(
     [TRADES_STORE_NAME, POSITIONS_STORE_NAME],
     "readwrite",
@@ -205,7 +206,7 @@ export async function importData(rawData: {
 
   await Promise.all([...tradePromises, ...positionPromises]);
   await tx.done;
-  console.log("Data imported successfully.");
+  logger.info("Data imported successfully.");
 }
 
 export async function clearAllData(): Promise<void> {
@@ -220,7 +221,7 @@ export async function clearAllData(): Promise<void> {
     tx.objectStore(PRICES_STORE_NAME).clear(),
   ]);
   await tx.done;
-  console.log("All trade, position, and price data cleared.");
+  logger.info("All trade, position, and price data cleared.");
 }
 
 export async function clearAndImportData(rawData: {
@@ -230,7 +231,7 @@ export async function clearAndImportData(rawData: {
   await clearAllData();
 
   const db = await getDb();
-  console.log("Importing data...");
+  logger.info("Importing data...");
   const tx = db.transaction(
     [TRADES_STORE_NAME, POSITIONS_STORE_NAME],
     "readwrite",
@@ -289,7 +290,7 @@ export async function clearAndImportData(rawData: {
   } catch {
     /* ignore */
   }
-  console.log("Data imported successfully after clearing.");
+  logger.info("Data imported successfully after clearing.");
 }
 
 export async function exportData(): Promise<{
@@ -442,9 +443,9 @@ export async function addTrade(trade: Trade): Promise<number> {
 export async function updateTrade(trade: Trade): Promise<void> {
   if (trade.id == null) throw new Error("Trade id is required for update");
   const db = await getDb();
-  console.log("更新交易:", trade);
+  logger.info("更新交易:", trade);
   await db.put(TRADES_STORE_NAME, trade);
-  console.log("交易更新成功");
+  logger.info("交易更新成功");
 }
 
 export async function deleteTrade(id: number): Promise<void> {

--- a/apps/web/app/lib/services/priceService.ts
+++ b/apps/web/app/lib/services/priceService.ts
@@ -3,6 +3,7 @@
 import { getPrice, putPrice, CachedPrice } from './dataService';
 import { loadJson } from '@/app/lib/dataSource';
 import { apiQueue } from './apiQueue';
+import { logger } from '@/lib/logger';
 
 // 将收盘价写入服务器端 JSON 文件
 async function saveToFile(symbol: string, date: string, close: number) {
@@ -228,7 +229,7 @@ let _freezeLogged = false;
 export async function fetchRealtimeQuote(symbol: string): Promise<QuoteResult> {
   if (freezeDate) {
     if (!_freezeLogged) {
-      console.info('EVAL_FREEZE', { date: freezeDate, source: 'close_prices.json' });
+      logger.info('EVAL_FREEZE', { date: freezeDate, source: 'close_prices.json' });
       _freezeLogged = true;
     }
     return fetchDailyClose(symbol, freezeDate);

--- a/apps/web/app/modules/PositionsTable.tsx
+++ b/apps/web/app/modules/PositionsTable.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import type { EnrichedTrade } from '@/lib/fifo';
 import { useStore } from '@/lib/store';
 import { formatCurrency } from '@/lib/metrics';
+import { logger } from '@/lib/logger';
 
 function formatNumber(value: number | undefined, decimals = 2) {
   if (value === undefined || value === null) return '--';
@@ -65,8 +66,8 @@ export function PositionsTable({ positions, trades }: Props) {
   // 计算市值和浮动盈亏
   const marketValues = useMemo(() => {
     // 添加日志帮助调试
-    console.log('持仓数据:', positions);
-    console.log('Price API results:', positions.map((pos, idx) => ({
+    logger.debug('持仓数据:', positions);
+    logger.debug('Price API results:', positions.map((pos, idx) => ({
       symbol: pos.symbol,
       qty: pos.qty,
       avgPrice: pos.avgPrice,
@@ -86,7 +87,7 @@ export function PositionsTable({ positions, trades }: Props) {
       // 按 (实时价格 - 成本价格) × 数量 计算浮动盈亏
       const unrealized = (lastPrice - pos.avgPrice) * pos.qty;
 
-      console.log(`${pos.symbol} 市值计算:`, {
+      logger.debug(`${pos.symbol} 市值计算:`, {
         lastPrice,
         qty: pos.qty,
         isShort,
@@ -102,14 +103,14 @@ export function PositionsTable({ positions, trades }: Props) {
 
   // 计算总计
   const totals = useMemo(() => {
-    console.log('计算总计，marketValues:', marketValues);
+    logger.debug('计算总计，marketValues:', marketValues);
 
     const totalMarketValue = marketValues.reduce((sum, item) => sum + item.market, 0);
     const totalUnrealized = marketValues.reduce((sum, item) => sum + item.unrealized, 0);
     const totalRealized = metrics?.M9 || 0; // 所有历史平仓盈利
     const totalPnL = totalUnrealized + totalRealized;
 
-    console.log('总计结果:', {
+    logger.debug('总计结果:', {
       totalMarketValue,
       totalUnrealized,
       totalRealized,

--- a/apps/web/app/trades/page.tsx
+++ b/apps/web/app/trades/page.tsx
@@ -6,6 +6,7 @@ import { findTrades, deleteTrade } from '@/lib/services/dataService';
 import { computeFifo, type EnrichedTrade } from '@/lib/fifo';
 import AddTradeModal from '@/components/AddTradeModal';
 import { toNY } from '@/lib/timezone';
+import { logger } from '@/lib/logger';
 
 export default function TradesPage() {
   const [trades, setTrades] = useState<EnrichedTrade[]>([]);
@@ -24,7 +25,7 @@ export default function TradesPage() {
         }
         const validTrades = fetchedTrades.filter(t => !!t.action);
         if (validTrades.length === 0) {
-          console.info('No valid trades found in fetched data');
+          logger.info('No valid trades found in fetched data');
         }
         setTrades(computeFifo(validTrades));
 
@@ -50,7 +51,7 @@ export default function TradesPage() {
     }
     const valid = fetched.filter(t => !!t.action);
     if (valid.length === 0) {
-      console.info('No valid trades found when reloading');
+      logger.info('No valid trades found when reloading');
     }
     setTrades(computeFifo(valid));
   };
@@ -128,7 +129,7 @@ export default function TradesPage() {
                 <td>{formatNumber(trade.averageCost)}</td>
                 <td>
                   <button className="btn-action btn-edit" data-tooltip="编辑" onClick={() => {
-                    console.log('编辑交易:', trade);
+                    logger.debug('编辑交易:', trade);
                     setEditingTrade(trade);
                   }}>✏️</button>
                 </td>
@@ -136,7 +137,7 @@ export default function TradesPage() {
                   <button className="btn-action btn-del" data-tooltip="删除" onClick={async () => {
                     if (confirm('确定删除该交易?')) {
                       if (trade.id != null) {
-                        console.log('删除交易:', trade.id);
+                        logger.debug('删除交易:', trade.id);
                         await deleteTrade(trade.id);
                         await reload();
                       }

--- a/apps/web/components/AddTradeModal.tsx
+++ b/apps/web/components/AddTradeModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { addTrade, updateTrade } from '@/lib/services/dataService';
 import type { EnrichedTrade } from '@/lib/fifo';
 import { nowNY, toNY } from '@/lib/timezone';
+import { logger } from '@/lib/logger';
 
 type Side = 'BUY' | 'SELL' | 'SHORT' | 'COVER';
 
@@ -22,7 +23,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
 
   useEffect(() => {
     if (trade) {
-      console.log('编辑交易:', trade);
+      logger.debug('编辑交易:', trade);
       setSymbol(trade.symbol);
       // 将action转换为大写，确保匹配Side类型
       const action = trade.action;
@@ -37,7 +38,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
       try {
         const formattedDate = toNY(trade.date).toISOString().slice(0, 10);
         setDate(formattedDate);
-        console.log('设置日期:', formattedDate, '原始日期:', trade.date);
+        logger.debug('设置日期:', formattedDate, '原始日期:', trade.date);
       } catch (e) {
         console.error('日期格式错误:', trade.date, e);
         // 回退到当前日期
@@ -56,7 +57,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
     // 确保action是小写的
     const action = side.toLowerCase() as 'buy' | 'sell' | 'short' | 'cover';
 
-    console.log('提交交易:', {
+    logger.debug('提交交易:', {
       id: editing ? trade?.id : undefined,
       symbol,
       price,

--- a/apps/web/public/js/equityCurve.js
+++ b/apps/web/public/js/equityCurve.js
@@ -161,7 +161,7 @@
     else curve.push(newPoint);
     saveCurve(curve);
 
-    console.log("资金收益曲线已自动更新", newPoint);
+    // 自动更新资金收益曲线
   }
   run();
 })();

--- a/apps/web/public/js/historicalBackfill.js
+++ b/apps/web/public/js/historicalBackfill.js
@@ -26,7 +26,6 @@ export async function runHistoricalBackfill(progressCallback = () => {}) {
       const candles = await fetchDailyCandles(sym, startEpoch, endEpoch);
       if (candles?.c?.length) {
         await saveDailyClosesBulk(sym, candles.t, candles.c);
-        console.log('[Backfill] saved', sym, candles.c.length, 'days');
       } else {
         console.warn('[Backfill] empty candle', sym, candles);
       }
@@ -35,7 +34,6 @@ export async function runHistoricalBackfill(progressCallback = () => {}) {
     }
     await new Promise(r => setTimeout(r, DELAY_PER_CALL_MS));
   }
-  console.log('[Backfill] completed');
 }
 
 // CLI support (Node): `node js/historicalBackfill.js`


### PR DESCRIPTION
## Summary
- add centralized logger with log-level support
- route existing debug statements through logger
- drop stray console.log calls in public scripts

## Testing
- `npm run lint` (fails: command exited with code 2 in packages/ui)
- `npm test` (fails: Preset ts-jest/presets/default-esm not found)


------
https://chatgpt.com/codex/tasks/task_e_68a115ee4924832ea50587c697b86afe