### PR TITLE
feat: log symbol name fetch errors

### DIFF
--- a/apps/web/app/modules/PositionsTable.tsx
+++ b/apps/web/app/modules/PositionsTable.tsx
@@ -49,7 +49,7 @@ export function PositionsTable({ positions, trades }: Props) {
     fetch('/data/symbol_name_map.json')
       .then((res) => res.json())
       .then((json) => setNameMap(json))
-      .catch(() => { });
+      .catch(err => console.error('加载符号名称失败', err));
   }, []);
 
   const getTradeCount = (symbol: string) => {

--- a/apps/web/app/modules/TradesTable.tsx
+++ b/apps/web/app/modules/TradesTable.tsx
@@ -16,7 +16,7 @@ export function TradesTable({ trades }: { trades: EnrichedTrade[] }) {
     fetch('/data/symbol_name_map.json')
       .then((r) => r.json())
       .then((j) => setNameMap(j))
-      .catch(() => { });
+      .catch(err => console.error('加载符号名称失败', err));
   }, []);
 
   const invalidTrades = trades.filter(t => !t.action);

--- a/apps/web/app/stock/page.tsx
+++ b/apps/web/app/stock/page.tsx
@@ -48,7 +48,7 @@ export default function StockPage() {
         fetch('/data/symbol_name_map.json')
           .then((r) => r.json())
           .then((j) => setNameMap(j))
-          .catch(() => { });
+          .catch(err => console.error('加载符号名称失败', err));
       } catch (e) {
         console.error(e);
       } finally {

--- a/apps/web/app/trades/page.tsx
+++ b/apps/web/app/trades/page.tsx
@@ -33,7 +33,7 @@ export default function TradesPage() {
         fetch('/data/symbol_name_map.json')
           .then((r) => r.json())
           .then((j) => setNameMap(j))
-          .catch(() => { });
+          .catch(err => console.error('加载符号名称失败', err));
       } catch (e) {
         console.error(e);
       } finally {


### PR DESCRIPTION
## Summary
- log failures when loading symbol name map

## Testing
- `npm test` *(fails: Preset ts-jest/presets/default-esm not found)*
- `npm run lint` *(fails: Cannot find package '@repo/eslint-config')*


------
https://chatgpt.com/codex/tasks/task_e_68a118124724832ebb884eaf43d8d2b1