### PR TITLE
refactor: reuse sorted trades across metrics

### DIFF
--- a/apps/web/app/lib/__tests__/calcTodayTradePnL.test.ts
+++ b/apps/web/app/lib/__tests__/calcTodayTradePnL.test.ts
@@ -1,4 +1,5 @@
 import { calcTodayTradePnL } from "@/lib/calcTodayTradePnL";
+import { sortTrades } from "@/lib/sortTrades";
 import type { EnrichedTrade } from "@/lib/fifo";
 
 describe("calcTodayTradePnL sorting", () => {
@@ -7,7 +8,7 @@ describe("calcTodayTradePnL sorting", () => {
       { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
       { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
     ];
-    const pnl = calcTodayTradePnL(trades, "2024-08-20");
+    const pnl = calcTodayTradePnL(sortTrades(trades), "2024-08-20");
     expect(pnl).toBe(0);
   });
 
@@ -17,8 +18,10 @@ describe("calcTodayTradePnL sorting", () => {
       { symbol: "T", action: "buy", price: 100, quantity: 1, date: "2024-08-20T09:00:00Z" } as unknown as EnrichedTrade,
       { symbol: "T", action: "sell", price: 110, quantity: 1, date: "2024-08-20T10:00:00Z" } as unknown as EnrichedTrade,
     ];
-    expect(() => calcTodayTradePnL(trades, "2024-08-20")).not.toThrow();
-    const pnl = calcTodayTradePnL(trades, "2024-08-20");
+    expect(() =>
+      calcTodayTradePnL(sortTrades(trades), "2024-08-20"),
+    ).not.toThrow();
+    const pnl = calcTodayTradePnL(sortTrades(trades), "2024-08-20");
     expect(pnl).toBe(10);
   });
 });

--- a/apps/web/app/lib/__tests__/metrics-fifo-date.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-fifo-date.test.ts
@@ -1,4 +1,5 @@
 import { calcTodayFifoPnL, calcHistoryFifoPnL } from "@/lib/metrics";
+import { sortTrades } from "@/lib/sortTrades";
 import type { EnrichedTrade } from "@/lib/fifo";
 
 describe("FIFO date validation", () => {
@@ -14,7 +15,7 @@ describe("FIFO date validation", () => {
       { symbol: "AAPL", action: "sell", price: 120, quantity: 1, date: "2024-01-03T10:00:00Z" } as unknown as EnrichedTrade,
     ];
     const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const pnl = calcTodayFifoPnL(trades, "2024-01-02");
+    const pnl = calcTodayFifoPnL(sortTrades(trades), "2024-01-02");
     expect(pnl).toBe(20);
     expect(warn).toHaveBeenCalledTimes(2);
   });
@@ -27,7 +28,7 @@ describe("FIFO date validation", () => {
       { symbol: "AAPL", action: "sell", price: 120, quantity: 1, date: "2024-01-03T10:00:00Z" } as unknown as EnrichedTrade,
     ];
     const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const pnl = calcHistoryFifoPnL(trades, "2024-01-02");
+    const pnl = calcHistoryFifoPnL(sortTrades(trades), "2024-01-02");
     expect(pnl).toBe(20);
     expect(warn).toHaveBeenCalledTimes(2);
   });

--- a/apps/web/app/lib/calcTodayTradePnL.ts
+++ b/apps/web/app/lib/calcTodayTradePnL.ts
@@ -17,78 +17,57 @@ function isTodayNY(dateStr: string | undefined, todayStr: string): boolean {
  * 计算日内交易盈亏（交易视角）
  * 按照交易匹配的方式，计算同一天内开仓并平仓的交易盈亏
  *
- * @param enrichedTrades 交易记录数组
+ * @param sortedTrades 已按时间排序的交易记录数组
  * @param todayStr 今日日期字符串，格式为 YYYY-MM-DD
  * @returns 日内交易盈亏
  */
-export function calcTodayTradePnL(enrichedTrades: EnrichedTrade[], todayStr: string): number {
+export function calcTodayTradePnL(
+  sortedTrades: EnrichedTrade[],
+  todayStr: string,
+): number {
   // 为多头和空头分别维护栈
   const longMap: Record<string, { qty: number; price: number }[]> = {};
   const shortMap: Record<string, { qty: number; price: number }[]> = {};
   let pnl = 0;
 
-  const sorted = enrichedTrades
-    .map((t, idx) => ({ t, idx }))
-    .filter(({ t }) => isTodayNY(t.date, todayStr))
-    .sort((a, b) => {
-      const timeA = toNY(a.t.date).getTime();
-      const timeB = toNY(b.t.date).getTime();
-      const aTime = isNaN(timeA) ? Infinity : timeA;
-      const bTime = isNaN(timeB) ? Infinity : timeB;
-      return aTime - bTime || a.idx - b.idx;
-    })
-    .map(({ t }) => t);
-  for (const t of sorted) {
-      const { symbol, action, price } = t;
-      const quantity = Math.abs(t.quantity);
+  for (const t of sortedTrades) {
+    if (!isTodayNY(t.date, todayStr)) continue;
+    const { symbol, action, price } = t;
+    const quantity = Math.abs(t.quantity);
 
-      // 初始化栈
-      if (!longMap[symbol]) longMap[symbol] = [];
-      if (!shortMap[symbol]) shortMap[symbol] = [];
+    if (!longMap[symbol]) longMap[symbol] = [];
+    if (!shortMap[symbol]) shortMap[symbol] = [];
 
-      if (action === 'buy') {
-        // 买入：直接加入多头栈
-        longMap[symbol].push({ qty: quantity, price });
+    if (action === "buy") {
+      longMap[symbol].push({ qty: quantity, price });
+    } else if (action === "sell") {
+      const longStack = longMap[symbol];
+      let remain = quantity;
+
+      while (remain > 0 && longStack.length > 0) {
+        const batch = longStack[0]!;
+        const q = Math.min(batch.qty, remain);
+        pnl += (price - batch.price) * q;
+        batch.qty -= q;
+        remain -= q;
+        if (batch.qty === 0) longStack.shift();
       }
-      else if (action === 'sell') {
-        // 卖出：匹配今日多头栈
-        const longStack = longMap[symbol];
-        let remain = quantity;
+    } else if (action === "short") {
+      shortMap[symbol].push({ qty: quantity, price });
+    } else if (action === "cover") {
+      const shortStack = shortMap[symbol];
+      let remain = quantity;
 
-        while (remain > 0 && longStack.length > 0) {
-          const batch = longStack[0]!;
-          const q = Math.min(batch.qty, remain);
-          // 多头平仓：卖出价 > 买入价 = 盈利
-          pnl += (price - batch.price) * q;
-          batch.qty -= q;
-          remain -= q;
-          if (batch.qty === 0) longStack.shift();
-        }
-
-        // 剩余的不处理（可能是平历史仓位，不计入日内交易）
-      }
-      else if (action === 'short') {
-        // 做空：直接加入空头栈
-        shortMap[symbol].push({ qty: quantity, price });
-      }
-      else if (action === 'cover') {
-        // 回补：匹配今日空头栈
-        const shortStack = shortMap[symbol];
-        let remain = quantity;
-
-        while (remain > 0 && shortStack.length > 0) {
-          const batch = shortStack[0]!;
-          const q = Math.min(batch.qty, remain);
-          // 空头平仓：回补价 < 做空价 = 盈利
-          pnl += (batch.price - price) * q;
-          batch.qty -= q;
-          remain -= q;
-          if (batch.qty === 0) shortStack.shift();
-        }
-
-        // 剩余的不处理（可能是平历史仓位，不计入日内交易）
+      while (remain > 0 && shortStack.length > 0) {
+        const batch = shortStack[0]!;
+        const q = Math.min(batch.qty, remain);
+        pnl += (batch.price - price) * q;
+        batch.qty -= q;
+        remain -= q;
+        if (batch.qty === 0) shortStack.shift();
       }
     }
+  }
 
   return pnl;
 }

--- a/apps/web/app/lib/sortTrades.ts
+++ b/apps/web/app/lib/sortTrades.ts
@@ -1,0 +1,21 @@
+import type { EnrichedTrade } from "@/lib/fifo";
+import { toNY } from "@/lib/timezone";
+
+/**
+ * Sort trades chronologically by their date field.
+ * Invalid dates are placed at the end while preserving original order.
+ */
+export function sortTrades(trades: EnrichedTrade[]): EnrichedTrade[] {
+  return trades
+    .map((t, idx) => ({ t, idx }))
+    .sort((a, b) => {
+      const timeA = toNY(a.t.date).getTime();
+      const timeB = toNY(b.t.date).getTime();
+      const aTime = isNaN(timeA) ? Infinity : timeA;
+      const bTime = isNaN(timeB) ? Infinity : timeB;
+      return aTime - bTime || a.idx - b.idx;
+    })
+    .map(({ t }) => t);
+}
+
+export default sortTrades;


### PR DESCRIPTION
## Summary
- centralize trade sorting via new `sortTrades` helper
- pass pre-sorted trades into PnL and close-lot calculators to remove per-call sorting
- update metrics to sort once and reuse cached order

## Testing
- `npm test` (fails: Preset ts-jest/presets/default-esm not found)
- `npm run build` (fails: missing type definition file for 'react-dom')

------
https://chatgpt.com/codex/tasks/task_e_68a1258686bc832e8590707931748a8f