### PR TITLE
test: add multi-day FIFO and period boundary cases

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-fifo-multiday.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-fifo-multiday.test.ts
@@ -1,0 +1,18 @@
+import { calcTodayFifoPnL, calcHistoryFifoPnL } from "@/lib/metrics";
+import { sortTrades } from "@/lib/sortTrades";
+import type { EnrichedTrade } from "@/lib/fifo";
+
+describe("FIFO multi-day scenarios", () => {
+  it("handles mixed historical and same-day trades with partial closures", () => {
+    const trades: EnrichedTrade[] = [
+      { symbol: "AAPL", action: "buy", price: 90, quantity: 100, date: "2024-01-01T10:00:00Z" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "buy", price: 95, quantity: 50, date: "2024-01-02T09:30:00Z" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "sell", price: 105, quantity: 30, date: "2024-01-02T10:30:00Z" } as unknown as EnrichedTrade,
+      { symbol: "AAPL", action: "sell", price: 100, quantity: 60, date: "2024-01-02T11:00:00Z" } as unknown as EnrichedTrade,
+    ];
+    const sorted = sortTrades(trades);
+    const today = "2024-01-02";
+    expect(calcTodayFifoPnL(sorted, today)).toBe(400);
+    expect(calcHistoryFifoPnL(sorted, today)).toBe(400);
+  });
+});

--- a/apps/web/app/lib/__tests__/metrics-wtd-mtd-ytd.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-wtd-mtd-ytd.test.ts
@@ -11,4 +11,25 @@ describe("calcWtdMtdYtd", () => {
     const { wtd, mtd, ytd } = calcWtdMtdYtd(daily, "2024-01-03");
     expect({ wtd, mtd, ytd }).toEqual({ wtd: 140, mtd: 140, ytd: 140 });
   });
+
+  it("resets week and month boundaries correctly", () => {
+    const daily: DailyResult[] = [
+      { date: "2024-02-25", realized: 50, unrealizedDelta: 0 },
+      { date: "2024-02-28", realized: 100, unrealizedDelta: 0 },
+      { date: "2024-02-29", realized: 200, unrealizedDelta: 0 },
+      { date: "2024-03-01", realized: 300, unrealizedDelta: 0 },
+    ];
+    const { wtd, mtd, ytd } = calcWtdMtdYtd(daily, "2024-03-01");
+    expect({ wtd, mtd, ytd }).toEqual({ wtd: 600, mtd: 300, ytd: 650 });
+  });
+
+  it("ignores prior-year results for YTD and WTD", () => {
+    const daily: DailyResult[] = [
+      { date: "2023-12-31", realized: 100, unrealizedDelta: 0 },
+      { date: "2024-01-01", realized: 200, unrealizedDelta: 0 },
+      { date: "2024-01-02", realized: 300, unrealizedDelta: 0 },
+    ];
+    const { wtd, mtd, ytd } = calcWtdMtdYtd(daily, "2024-01-02");
+    expect({ wtd, mtd, ytd }).toEqual({ wtd: 500, mtd: 500, ytd: 500 });
+  });
 });


### PR DESCRIPTION
## Summary
- add FIFO multi-day test with mixed historical and same-day trades
- extend WTD/MTD/YTD tests across week, month, and year boundaries

## Testing
- `node node_modules/jest/bin/jest.js apps/web/app/lib/__tests__/metrics-fifo-multiday.test.ts` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21949fb44832e806725bed9a55f5f