### PR TITLE
fix: set turbo build logs full

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci --omit=dev
-      - run: npx --yes turbo run build --output-logs=stream
+      - run: npx --yes turbo run build --output-logs=full


### PR DESCRIPTION
## Summary
- build: set turbo run build output logs to full to avoid stream option

## Testing
- `npm test` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a28c462d58832ebe93668303ccceef