### PR TITLE
chore(ci): use full logs for turbo build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci --omit=dev
-      - run: npx --yes turbo run build --output-logs=stream
+      - run: npx --yes turbo run build --output-logs=full


### PR DESCRIPTION
## Summary
- run Turbo build with `--output-logs=full` in CI

## Testing
- `npx --yes turbo run build --output-logs=full` *(fails: Cannot find type definition file for 'yargs')*


------
https://chatgpt.com/codex/tasks/task_e_68a33c633b84832e81b67f184b6c11f0