### PR TITLE
chore: convert web PostCSS config to ESM

### DIFF
--- a/apps/web/postcss.config.cjs
+++ b/apps/web/postcss.config.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
-} 

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,5 +1,6 @@
-module.exports = {
+export default {
   plugins: {
-    "@tailwindcss/postcss": {}
-  }
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
 };


### PR DESCRIPTION
## Summary
- remove duplicate PostCSS config in web app
- convert PostCSS config to ESM format with Tailwind and autoprefixer plugins

## Testing
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42bce6e80832ea6fbc5022b9c6e71