### PR TITLE
chore: align turbo outputs for ui package

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "packages/ui/dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
## Summary
- set root turbo build outputs to `dist/**`

## Testing
- `npx -y turbo run build` *(fails: Cannot find type definition file for 'yargs')*

------
https://chatgpt.com/codex/tasks/task_e_68a4309e06cc832eb0a3ad4e3e589ec1