### PR TITLE
fix period metrics boundaries

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-wtd-mtd-ytd.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-wtd-mtd-ytd.test.ts
@@ -11,4 +11,14 @@ describe("calcWtdMtdYtd", () => {
     const { wtd, mtd, ytd } = calcWtdMtdYtd(daily, "2024-01-03");
     expect({ wtd, mtd, ytd }).toEqual({ wtd: 140, mtd: 140, ytd: 140 });
   });
+
+  it("excludes previous year data when week spans two years", () => {
+    const daily: DailyResult[] = [
+      { date: "2024-12-30", realized: 10, unrealized: 0, unrealizedDelta: 0 },
+      { date: "2024-12-31", realized: 20, unrealized: 0, unrealizedDelta: 0 },
+      { date: "2025-01-01", realized: 30, unrealized: 0, unrealizedDelta: 0 },
+    ];
+    const { wtd, mtd, ytd } = calcWtdMtdYtd(daily, "2025-01-01");
+    expect({ wtd, mtd, ytd }).toEqual({ wtd: 30, mtd: 30, ytd: 30 });
+  });
 });

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -15,6 +15,7 @@ import type { DailyResult } from "./types";
 import { sumRealized } from "./metrics-period";
 import { calcWinLossLots } from "./metrics-winloss";
 import { logger } from "@/lib/logger";
+import { isSameWeek, isSameMonth, isSameYear } from "date-fns";
 
 export function isDebug() {
   return (
@@ -327,14 +328,20 @@ export function sumPeriod(
 
 export function calcWtdMtdYtd(daily: DailyResult[], evalDateStr: string) {
   const evalDate = toNY(evalDateStr);
-  const wStart = startOfWeekNY(evalDate);
-  const mStart = startOfMonthNY(evalDate);
-  const yStart = startOfYearNY(evalDate);
-  const endStr = evalDateStr;
+  const calc = (fn: (d: Date) => boolean) =>
+    daily.reduce((total, r) => {
+      const d = toNY(r.date);
+      if (fn(d)) total += (r.realized ?? 0) + (r.unrealizedDelta ?? 0);
+      return total;
+    }, 0);
   return {
-    wtd: sumPeriod(daily, wStart.toISOString().slice(0, 10), endStr),
-    mtd: sumPeriod(daily, mStart.toISOString().slice(0, 10), endStr),
-    ytd: sumPeriod(daily, yStart.toISOString().slice(0, 10), endStr),
+    wtd: calc((d) =>
+      isSameYear(d, evalDate) && isSameWeek(d, evalDate, { weekStartsOn: 1 })
+    ),
+    mtd: calc((d) =>
+      isSameMonth(d, evalDate) && isSameYear(d, evalDate)
+    ),
+    ytd: calc((d) => isSameYear(d, evalDate)),
   };
 }
 


### PR DESCRIPTION
## Summary
- refine calcWtdMtdYtd with date-fns to restrict WTD, MTD, and YTD to the correct week/month/year
- add test covering year-boundary week handling

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42a47799c832eb01e17127edc5717