### PR TITLE
feat: add M6 consistency assertion

### DIFF
--- a/apps/web/app/lib/__tests__/metrics-assertM6.test.ts
+++ b/apps/web/app/lib/__tests__/metrics-assertM6.test.ts
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+
+describe('assertM6', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    (globalThis as any).window = {};
+    (globalThis as any).location = { search: '' };
+    process.env.NEXT_PUBLIC_DEBUG_METRICS = '1';
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).window;
+    delete (globalThis as any).location;
+    delete process.env.NEXT_PUBLIC_DEBUG_METRICS;
+    jest.restoreAllMocks();
+  });
+
+  it('does not warn when M6 matches', async () => {
+    const { assertM6 } = await import('../metrics');
+    const { logger } = await import('../logger');
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const metrics = {
+      M3: 1,
+      M4: 2,
+      M5: { trade: 0, fifo: 3 },
+      M6: 6,
+    } as any;
+    assertM6(metrics);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when M6 mismatches', async () => {
+    const { assertM6 } = await import('../metrics');
+    const { logger } = await import('../logger');
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const metrics = {
+      M3: 1,
+      M4: 2,
+      M5: { trade: 0, fifo: 3 },
+      M6: 7,
+    } as any;
+    assertM6(metrics);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -144,6 +144,19 @@ function round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
 
+export function assertM6(metrics: Metrics) {
+  if (!DEBUG) return;
+  const expected = round2(metrics.M4 + metrics.M3 + metrics.M5.fifo);
+  if (metrics.M6 !== expected)
+    logger.warn("M6 mismatch", {
+      M4: metrics.M4,
+      M3: metrics.M3,
+      fifo: metrics.M5.fifo,
+      M6: metrics.M6,
+      expected,
+    });
+}
+
 function _count(list: { action?: string }[] | undefined) {
   const res = { B: 0, S: 0, P: 0, C: 0, total: 0 };
   if (!Array.isArray(list)) return res;
@@ -864,7 +877,7 @@ export function calcMetrics(
   // M11-13: 周期性指标
   const { wtd, mtd, ytd } = calcWtdMtdYtd(historicalDailyResults, todayStr);
 
-  return {
+  const metrics: Metrics = {
     M1: totalCost,
     M2: currentValue,
     M3: floatPnl,
@@ -899,6 +912,10 @@ export function calcMetrics(
     M12: mtd,
     M13: ytd,
   };
+
+  assertM6(metrics);
+
+  return metrics;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `assertM6` to check M6 equals M4 + M3 + M5.fifo and warn when mismatched in debug mode
- integrate assertion into metric calculation
- cover M6 assertion with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4374ae9bc832ea7cc5a8f6b2c61db