### PR TITLE
feat(metrics): add unified NY timezone utilities and verifier

### DIFF
--- a/apps/web/app/lib/time.ts
+++ b/apps/web/app/lib/time.ts
@@ -1,0 +1,44 @@
+import { fromZonedTime as zonedTimeToUtc, toZonedTime as utcToZonedTime, formatInTimeZone } from 'date-fns-tz';
+import { startOfWeek, startOfMonth, startOfYear } from 'date-fns';
+
+export const NY_TZ = 'America/New_York';
+
+export function toNY(d: Date | string | number): Date {
+  const dt = typeof d === 'string' || typeof d === 'number' ? new Date(d) : d;
+  return utcToZonedTime(dt, NY_TZ);
+}
+
+export function isSameNYDay(a: Date | string | number, b: Date | string | number): boolean {
+  const A = toNY(a); const B = toNY(b);
+  return A.getFullYear() === B.getFullYear()
+    && A.getMonth() === B.getMonth()
+    && A.getDate() === B.getDate();
+}
+
+export function nyDateStr(d: Date | string | number): string {
+  return formatInTimeZone(d, NY_TZ, 'yyyy-MM-dd');
+}
+
+export function startOfDayNY(d: Date | string | number): Date {
+  const nd = toNY(d);
+  const local = new Date(nd.getFullYear(), nd.getMonth(), nd.getDate(), 0, 0, 0);
+  return zonedTimeToUtc(local, NY_TZ);
+}
+
+export function startOfWeekNY(d: Date | string | number): Date {
+  const nd = toNY(d);
+  const mondayLocal = startOfWeek(new Date(nd.getFullYear(), nd.getMonth(), nd.getDate()), { weekStartsOn: 1 });
+  return zonedTimeToUtc(mondayLocal, NY_TZ);
+}
+
+export function startOfMonthNY(d: Date | string | number): Date {
+  const nd = toNY(d);
+  const m0Local = startOfMonth(new Date(nd.getFullYear(), nd.getMonth(), nd.getDate()));
+  return zonedTimeToUtc(m0Local, NY_TZ);
+}
+
+export function startOfYearNY(d: Date | string | number): Date {
+  const nd = toNY(d);
+  const y0Local = startOfYear(new Date(nd.getFullYear(), nd.getMonth(), nd.getDate()));
+  return zonedTimeToUtc(y0Local, NY_TZ);
+}

--- a/apps/web/scripts/verify-nytime.ts
+++ b/apps/web/scripts/verify-nytime.ts
@@ -1,0 +1,7 @@
+import { isSameNYDay, nyDateStr } from '../app/lib/time';
+
+console.log('nyDateStr(2025-08-01T13:00:00Z)=', nyDateStr('2025-08-01T13:00:00Z'));
+if (!isSameNYDay('2025-08-01T13:00:00Z', '2025-08-01T21:00:00Z')) {
+  throw new Error('isSameNYDay failed on same NY day');
+}
+console.log('NY time utils verified ✅');


### PR DESCRIPTION
## Summary
- add unified New York timezone utilities for consistent date handling
- add verification script ensuring NY time utilities behave correctly

## Testing
- `npx -y tsx apps/web/scripts/verify-nytime.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c92086ec832e89e055766453e15e