### PR TITLE
feat(metrics): unify evalDate and derive M9/WTD/MTD/YTD from daily aggregates

### DIFF
--- a/apps/web/app/lib/metrics-periods.ts
+++ b/apps/web/app/lib/metrics-periods.ts
@@ -1,0 +1,31 @@
+import { nyDateStr, startOfWeekNY, startOfMonthNY, startOfYearNY } from './time';
+
+export type Daily = { date: string; realized: number; unrealized: number };
+
+export function sumM9(daily: Daily[]): number {
+  return (daily || []).reduce((s, d) => s + (d?.realized ?? 0), 0);
+}
+
+export function sumPeriod(daily: Daily[], startISO: string, endISO: string): number {
+  const start = new Date(startISO);
+  const end = new Date(endISO);
+  return (daily || [])
+    .filter(d => {
+      const dt = new Date(d.date);
+      return dt >= start && dt <= end;
+    })
+    .reduce((s, d) => s + (d?.realized ?? 0) + (d?.unrealized ?? 0), 0);
+}
+
+export function computePeriods(daily: Daily[], evalDate: Date | string) {
+  const endISO = nyDateStr(evalDate);
+  const w0 = nyDateStr(startOfWeekNY(evalDate));
+  const m0 = nyDateStr(startOfMonthNY(evalDate));
+  const y0 = nyDateStr(startOfYearNY(evalDate));
+  return {
+    M9:  sumM9(daily),
+    M11: sumPeriod(daily, w0, endISO),
+    M12: sumPeriod(daily, m0, endISO),
+    M13: sumPeriod(daily, y0, endISO),
+  };
+}

--- a/apps/web/scripts/verify-periods.ts
+++ b/apps/web/scripts/verify-periods.ts
@@ -1,0 +1,14 @@
+import { computePeriods } from '../app/lib/metrics-periods';
+
+const daily = [{ date: '2025-08-01', realized: 7850, unrealized: 1102.5 }];
+const { M9, M11, M12, M13 } = computePeriods(daily, '2025-08-01');
+
+console.log({ M9, M11, M12, M13 });
+
+function eq(a:number,b:number){ return Math.abs(a-b) < 1e-6; }
+if (!eq(M9, 7850)) throw new Error('M9 expected 7850');
+if (!eq(M11, 8952.5)) throw new Error('M11 expected 8952.5');
+if (!eq(M12, 8952.5)) throw new Error('M12 expected 8952.5');
+if (!eq(M13, 8952.5)) throw new Error('M13 expected 8952.5');
+
+console.log('period metrics verified ✅');


### PR DESCRIPTION
## Summary
- add period aggregation helpers to compute M9/M11/M12/M13
- derive evaluation date from options and compute periods in runAll
- add verify script for period calculations

## Testing
- `npx -y tsx apps/web/scripts/verify-periods.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5d6165cc8832eab3e785bebdcfd03