### PR TITLE
feat(periods): scoped & content-hash invalidated cache for period sums

### DIFF
--- a/apps/web/app/lib/metrics-periods.ts
+++ b/apps/web/app/lib/metrics-periods.ts
@@ -1,4 +1,5 @@
 import { nyDateStr, startOfWeekNY, startOfMonthNY, startOfYearNY } from './time';
+import { sumPeriodCached } from './period-sum-cache';
 
 export type Daily = { date: string; realized: number; unrealized: number };
 
@@ -24,8 +25,8 @@ export function computePeriods(daily: Daily[], evalDate: Date | string) {
   const y0 = nyDateStr(startOfYearNY(evalDate));
   return {
     M9:  sumM9(daily),
-    M11: sumPeriod(daily, w0, endISO),
-    M12: sumPeriod(daily, m0, endISO),
-    M13: sumPeriod(daily, y0, endISO),
+    M11: sumPeriodCached(daily, w0, endISO),
+    M12: sumPeriodCached(daily, m0, endISO),
+    M13: sumPeriodCached(daily, y0, endISO),
   };
 }

--- a/apps/web/app/lib/period-sum-cache.ts
+++ b/apps/web/app/lib/period-sum-cache.ts
@@ -1,0 +1,43 @@
+import type { Daily } from './metrics-periods';
+
+/** 仅保留参与求和的核心字段，做稳定 stringify，再哈希 */
+function stableKeyForDaily(daily: Daily[]): string {
+  const norm = (daily || []).map(d => [d.date, +(d.realized||0), +(d.unrealized||0)]);
+  const json = JSON.stringify(norm);
+  // 简单 djb2 哈希，足够做 cache key
+  let h = 5381;
+  for (let i = 0; i < json.length; i++) h = ((h << 5) + h) ^ json.charCodeAt(i);
+  return (h >>> 0).toString(36) + `~${norm.length}`;
+}
+
+type Inner = Map<string, number>; // key: "start|end" -> sum
+const CACHE = new Map<string, Inner>(); // key: datasetKey
+
+/** 清理过大的缓存，避免内存无限增长（极简 LRU：超 32 个数据集时清空最早的 8 个） */
+function gc() {
+  if (CACHE.size <= 32) return;
+  const toDelete = Array.from(CACHE.keys()).slice(0, 8);
+  toDelete.forEach(k => CACHE.delete(k));
+}
+
+/** 带缓存的周期求和（包含 realized+unrealized） */
+export function sumPeriodCached(daily: Daily[], startISO: string, endISO: string): number {
+  const dsKey = stableKeyForDaily(daily);
+  let inner = CACHE.get(dsKey);
+  if (!inner) { inner = new Map(); CACHE.set(dsKey, inner); gc(); }
+
+  const key = `${startISO}|${endISO}`;
+  if (inner.has(key)) return inner.get(key)!;
+
+  const start = new Date(startISO);
+  const end   = new Date(endISO);
+  let s = 0;
+  for (const d of daily || []) {
+    const dt = new Date(d.date);
+    if (dt >= start && dt <= end) {
+      s += (d?.realized ?? 0) + (d?.unrealized ?? 0);
+    }
+  }
+  inner.set(key, s);
+  return s;
+}

--- a/apps/web/scripts/verify-periods-cache.ts
+++ b/apps/web/scripts/verify-periods-cache.ts
@@ -11,7 +11,8 @@ let p1 = computePeriods(A as any, '2025-08-04');
 if (Math.abs(p1.M12 - (7850+1102.5+50-10)) > 1e-6) throw new Error('baseline wrong');
 
 // 原地修改 A 的第一天 → 缓存必须失效
-A[0].realized += 100;
+const first = A[0]!;     // 保证非空（我们显式构造了 A 的两条记录）
+first.realized += 100;
 let p2 = computePeriods(A as any, '2025-08-04');
 if (Math.abs(p2.M12 - (7950+1102.5+50-10)) > 1e-6) throw new Error('in-place mutation not reflected');
 

--- a/apps/web/scripts/verify-periods-cache.ts
+++ b/apps/web/scripts/verify-periods-cache.ts
@@ -1,0 +1,23 @@
+import { computePeriods } from '../app/lib/metrics-periods';
+
+// 数据集 A
+const A = [
+  { date: '2025-08-01', realized: 7850, unrealized: 1102.5 },
+  { date: '2025-08-04', realized:   50, unrealized:   -10  },
+];
+
+// 首次计算
+let p1 = computePeriods(A as any, '2025-08-04');
+if (Math.abs(p1.M12 - (7850+1102.5+50-10)) > 1e-6) throw new Error('baseline wrong');
+
+// 原地修改 A 的第一天 → 缓存必须失效
+A[0].realized += 100;
+let p2 = computePeriods(A as any, '2025-08-04');
+if (Math.abs(p2.M12 - (7950+1102.5+50-10)) > 1e-6) throw new Error('in-place mutation not reflected');
+
+// 数据集 B（与 A 当前内容相同但引用不同）→ 作用域隔离（不同 key），亦应正确
+const B = JSON.parse(JSON.stringify(A));
+let p3 = computePeriods(B as any, '2025-08-04');
+if (Math.abs(p3.M12 - p2.M12) > 1e-6) throw new Error('dataset scoping wrong');
+
+console.log('period cache verified ✅');


### PR DESCRIPTION
## Summary
- add dataset-scoped period sum cache with content hash invalidation
- use cached period sums in computePeriods without changing API
- add verification script for cache behavior

## Testing
- `npx -y tsx apps/web/scripts/verify-periods-cache.ts`
- `npx -y tsx apps/web/scripts/verify-periods.ts`
- `npx -y tsx apps/web/scripts/verify-golden.ts` *(from apps/web)*
- `npx -y tsx apps/web/scripts/verify-m5-overflow.ts` *(from apps/web)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a637f8dba0832eb4b6452f0baa22e7