### PR TITLE
test: add property-based metrics check

### DIFF
--- a/apps/web/app/lib/__tests__/property-metrics.test.ts
+++ b/apps/web/app/lib/__tests__/property-metrics.test.ts
@@ -19,19 +19,19 @@ describe('property based metrics', () => {
       side: fc.constantFrom('BUY', 'SELL', 'SHORT', 'COVER'),
       symbol: fc.constantFrom(...symbols),
       qty: fc.integer({ min: 1, max: 5 }),
-      price: fc.float({ min: 1, max: 100 }),
+      price: fc.float({ min: 1, max: 100, noNaN: true, noDefaultInfinity: true }),
     });
 
     const dailyArb = fc.record({
       date: fc.constantFrom('2024-01-01', '2024-01-02', '2024-01-03'),
-      realized: fc.float({ min: -1000, max: 1000 }),
-      unrealized: fc.float({ min: -1000, max: 1000 }),
+      realized: fc.float({ min: -1000, max: 1000, noNaN: true, noDefaultInfinity: true }),
+      unrealized: fc.float({ min: -1000, max: 1000, noNaN: true, noDefaultInfinity: true }),
     });
 
     const closePriceArb = fc.tuple(
-      fc.float({ min: 1, max: 100 }),
-      fc.float({ min: 1, max: 100 }),
-      fc.float({ min: 1, max: 100 }),
+      fc.float({ min: 1, max: 100, noNaN: true, noDefaultInfinity: true }),
+      fc.float({ min: 1, max: 100, noNaN: true, noDefaultInfinity: true }),
+      fc.float({ min: 1, max: 100, noNaN: true, noDefaultInfinity: true }),
     ).map(([a, b, c]) => ({
       AAA: { [evalISO]: a },
       BBB: { [evalISO]: b },
@@ -58,7 +58,7 @@ describe('property based metrics', () => {
 
           const expectedM4 = round2(split.historyRealized);
           const expectedM5_2 = round2(split.fifo);
-          const expectedM9 = dailyResults.reduce((s, d) => s + (d.realized || 0), 0);
+          const expectedM9 = dailyResults.reduce((s, d) => s + d.realized, 0);
 
           expect(result.M4).toBeCloseTo(expectedM4, 10);
           expect(result.M5_2).toBeCloseTo(expectedM5_2, 10);

--- a/apps/web/app/lib/__tests__/property-metrics.test.ts
+++ b/apps/web/app/lib/__tests__/property-metrics.test.ts
@@ -1,0 +1,70 @@
+import fc from 'fast-check';
+import runAll from '@/lib/runAll';
+import { computeFifo } from '@/lib/fifo';
+import { calcM5Split } from '@/lib/m5-intraday';
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+describe('property based metrics', () => {
+  it('M4/M5.2/M9 match simplified calculation', () => {
+    const evalISO = '2024-01-03';
+    const symbols = ['AAA', 'BBB', 'CCC'];
+
+    const tradeArb = fc.record({
+      date: fc.constantFrom(
+        '2024-01-01T10:00:00Z',
+        '2024-01-02T10:00:00Z',
+        '2024-01-03T10:00:00Z',
+      ),
+      side: fc.constantFrom('BUY', 'SELL', 'SHORT', 'COVER'),
+      symbol: fc.constantFrom(...symbols),
+      qty: fc.integer({ min: 1, max: 5 }),
+      price: fc.float({ min: 1, max: 100 }),
+    });
+
+    const dailyArb = fc.record({
+      date: fc.constantFrom('2024-01-01', '2024-01-02', '2024-01-03'),
+      realized: fc.float({ min: -1000, max: 1000 }),
+      unrealized: fc.float({ min: -1000, max: 1000 }),
+    });
+
+    const closePriceArb = fc.tuple(
+      fc.float({ min: 1, max: 100 }),
+      fc.float({ min: 1, max: 100 }),
+      fc.float({ min: 1, max: 100 }),
+    ).map(([a, b, c]) => ({
+      AAA: { [evalISO]: a },
+      BBB: { [evalISO]: b },
+      CCC: { [evalISO]: c },
+    }));
+
+    fc.assert(
+      fc.property(
+        fc.array(tradeArb, { maxLength: 10 }),
+        fc.array(dailyArb, { maxLength: 5 }),
+        closePriceArb,
+        (rawTrades, dailyResults, closePrices) => {
+          const result = runAll(evalISO, [], rawTrades, closePrices, { dailyResults });
+
+          const fifoTrades = rawTrades.map(t => ({
+            symbol: t.symbol,
+            price: t.price,
+            quantity: t.qty,
+            date: t.date,
+            action: t.side.toLowerCase() as any,
+          }));
+          const enriched = computeFifo(fifoTrades, []);
+          const split = calcM5Split(enriched as any, evalISO, []);
+
+          const expectedM4 = round2(split.historyRealized);
+          const expectedM5_2 = round2(split.fifo);
+          const expectedM9 = dailyResults.reduce((s, d) => s + (d.realized || 0), 0);
+
+          expect(result.M4).toBeCloseTo(expectedM4, 10);
+          expect(result.M5_2).toBeCloseTo(expectedM5_2, 10);
+          expect(result.M9).toBeCloseTo(expectedM9, 10);
+        }
+      )
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "fake-indexeddb": "^6.0.1",
+        "fast-check": "^4.3.0",
         "jest": "^30.0.5",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.0",
@@ -5968,6 +5969,29 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.3.0.tgz",
+      "integrity": "sha512-JVw/DJSxVKl8uhCb7GrwanT9VWsCIdBkK3WpP37B/Au4pyaspriSjtrY2ApbSFwTg3ViPfniT13n75PhzE7VEQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "fake-indexeddb": "^6.0.1",
+    "fast-check": "^4.3.0",
     "jest": "^30.0.5",
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.0",


### PR DESCRIPTION
## Summary
- add fast-check dev dependency
- verify runAll M4/M5.2/M9 using property-based tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b361936ef0832e8665dc0f11a7f3c4