### PR TITLE
feat: add monitoring alerts for metrics

### DIFF
--- a/env.example
+++ b/env.example
@@ -19,4 +19,6 @@ VERCEL_ENV=production
 # Optional: freeze all price lookups to a specific trading day (YYYY-MM-DD)
 NEXT_PUBLIC_FREEZE_DATE=
 NEXT_PUBLIC_APP_URL=https://your-domain.com
+# Optional: endpoint to receive monitoring alerts
+NEXT_PUBLIC_MONITOR_URL=
 NODE_ENV=production


### PR DESCRIPTION
## Summary
- add generic monitor reporting helper
- log mismatched metrics and wrap calcMetrics in try/catch to report errors
- document monitoring endpoint in env.example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b36855e0f0832eac86dc6fd348e5f3