### PR TITLE
feat: add daily snapshot and history verification scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ yarn-error.log*
 .DS_Store
 Thumbs.db
 
+
+# Data snapshots
+apps/web/data/snapshots/

--- a/apps/web/scripts/snapshot.ts
+++ b/apps/web/scripts/snapshot.ts
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { nyDateStr } from "../app/lib/time";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const publicDir = path.resolve(__dirname, "../public");
+const snapshotRoot = path.resolve(__dirname, "../data/snapshots");
+
+const date = process.env.NEXT_PUBLIC_FREEZE_DATE || nyDateStr(new Date());
+const destDir = path.join(snapshotRoot, date);
+
+fs.mkdirSync(destDir, { recursive: true });
+
+for (const name of ["trades.json", "dailyResult.json"]) {
+  const src = path.join(publicDir, name);
+  if (!fs.existsSync(src)) {
+    console.warn(`${name} not found in public dir, skipping`);
+    continue;
+  }
+  fs.copyFileSync(src, path.join(destDir, name));
+}
+
+console.log(`Snapshot saved to ${destDir}`);

--- a/apps/web/scripts/verify-history.ts
+++ b/apps/web/scripts/verify-history.ts
@@ -1,0 +1,60 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import runAll, { RawTrade, ClosePriceMap } from "../app/lib/runAll";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function readJSON(p: string) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+const dataDir = path.resolve(__dirname, "../data/snapshots");
+const publicDir = path.resolve(__dirname, "../public");
+
+const positions = readJSON(path.join(publicDir, "initial_positions.json"));
+const closePrices: ClosePriceMap = readJSON(
+  path.join(publicDir, "close_prices.json"),
+);
+
+const dates = fs
+  .readdirSync(dataDir)
+  .filter((d) => /\d{4}-\d{2}-\d{2}/.test(d))
+  .sort();
+
+let trades: RawTrade[] = [];
+let dailyResults: { date: string; realized: number; unrealized: number }[] = [];
+
+for (const date of dates) {
+  const dayDir = path.join(dataDir, date);
+  const dayTrades: RawTrade[] = readJSON(path.join(dayDir, "trades.json"));
+  trades = trades.concat(dayTrades);
+
+  const res = runAll(
+    date,
+    positions,
+    trades,
+    closePrices,
+    { dailyResults },
+    { evalDate: date },
+  );
+  const realized = Math.round((res.M4 + res.M5_2) * 100) / 100;
+  const unrealized = Math.round(res.M3 * 100) / 100;
+
+  const snapshotDaily = readJSON(path.join(dayDir, "dailyResult.json"));
+  const record = snapshotDaily.find((r: any) => r.date === date);
+  if (!record) {
+    throw new Error(`missing dailyResult for ${date}`);
+  }
+  const tol = 0.01;
+  if (
+    Math.abs(record.realized - realized) > tol ||
+    Math.abs(record.unrealized - unrealized) > tol
+  ) {
+    throw new Error(`mismatch on ${date}`);
+  }
+
+  dailyResults.push({ date, realized, unrealized });
+}
+
+console.log("✅ history verified");

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "check-types": "npx --yes turbo run check-types",
     "test": "npx --yes jest apps/web/app/lib",
     "verify:golden": "tsx --tsconfig apps/web/tsconfig.json apps/web/scripts/verify-golden.ts",
+    "snapshot:daily": "tsx --tsconfig apps/web/tsconfig.json apps/web/scripts/snapshot.ts",
+    "verify:history": "tsx --tsconfig apps/web/tsconfig.json apps/web/scripts/verify-history.ts",
     "ci:pr": "npm run verify:golden && turbo run build --filter=!web --output-logs=errors-only"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add snapshot script to store daily trades and results
- add verify-history script to recompute metrics for each day and compare snapshots
- expose snapshot/verification utilities via npm scripts and ignore generated files

## Testing
- `npm test`
- `NEXT_PUBLIC_FREEZE_DATE=2025-08-01 npm run snapshot:daily`
- `npm run verify:history`


------
https://chatgpt.com/codex/tasks/task_e_68b369e87c9c832ea56518668e476cd0