### PR TITLE
feat: add real backtest smoke testing

### DIFF
--- a/.github/workflows/post-merge-smoke.yml
+++ b/.github/workflows/post-merge-smoke.yml
@@ -1,0 +1,15 @@
+name: post-merge-smoke
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch: {}
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - run: npm ci
+      - run: npm run ci
+      - run: npm run backtest:smoke -w web

--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: ["next/core-web-vitals"],
+  rules: {
+    "no-restricted-properties": ["error",
+      { "objectPattern": "result", "property": "M5_1", "message": "Use normalizeMetrics(...).M5.behavior" },
+      { "objectPattern": "result", "property": "M5_2", "message": "Use normalizeMetrics(...).M5.fifo" }
+    ]
+  }
+};

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -61,3 +61,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## 真实回放（Real Backtest）
+- 文档：./../../docs/REAL_BACKTEST.md
+- 快速命令：`npm run backtest:smoke -w web`（黄金用例）
+- 自定义区间：`npm run backtest -w web -- --from=YYYY-MM-DD --to=YYYY-MM-DD`

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,4 +1,15 @@
 import { nextJsConfig } from "@repo/eslint-config/next-js";
 
-/** @type {import("eslint").Linter.Config} */
-export default nextJsConfig;
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...nextJsConfig,
+  {
+    rules: {
+      "no-restricted-properties": [
+        "error",
+        { object: "result", property: "M5_1", message: "Use normalizeMetrics(...).M5.behavior" },
+        { object: "result", property: "M5_2", message: "Use normalizeMetrics(...).M5.fifo" },
+      ],
+    },
+  },
+];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
     "replay": "tsx scripts/replay.ts",
     "check:monitor": "MONITOR=1 npm run replay",
     "test": "jest",
-    "check:types": "tsc --noEmit"
+    "check:types": "tsc --noEmit",
+    "backtest:smoke": "node ./scripts/replay.js --from=2025-08-01 --to=2025-08-01 || node ./scripts/replay.ts --from=2025-08-01 --to=2025-08-01"
   },
   "dependencies": {
     "@radix-ui/react-tabs": "^1.1.12",

--- a/data/real/templates/prices.csv
+++ b/data/real/templates/prices.csv
@@ -1,0 +1,2 @@
+date,symbol,close
+2025-08-01,TSLA,302.63

--- a/data/real/templates/trades.csv
+++ b/data/real/templates/trades.csv
@@ -1,0 +1,2 @@
+date,time,symbol,side,qty,price
+2025-08-01,09:35,TSLA,BUY,200,295

--- a/docs/REAL_BACKTEST.md
+++ b/docs/REAL_BACKTEST.md
@@ -1,0 +1,44 @@
+# 真实回放（Real Backtest）
+
+> 目的：把你的“真实多日交易 + 收盘价”导入 `data/real/`，离线回放并生成每日快照（realized、unrealized、M1–M13）。
+
+## 目录结构
+```
+data/
+  real/
+    trades.csv           # 或 trades.json（二选一）
+    prices.csv           # 或 prices.json（二选一）
+    dailyResult.json     # 回放生成
+```
+
+## trades.csv 格式
+必需列：date,time,symbol,side,qty,price
+- date: YYYY-MM-DD（交易日）
+- time: HH:mm（本地时间）
+- side: BUY | SELL | SHORT | COVER
+- qty: 正整数
+- price: 成交价
+
+示例：
+```csv
+date,time,symbol,side,qty,price
+2025-08-01,09:35,TSLA,BUY,200,295
+2025-08-01,09:38,TSLA,SELL,50,301
+```
+
+## prices.csv 格式
+必需列：date,symbol,close
+示例：
+```csv
+date,symbol,close
+2025-08-01,TSLA,302.63
+```
+
+## 运行回放
+```bash
+npm run backtest -w web -- --from=YYYY-MM-DD --to=YYYY-MM-DD
+```
+
+## 产出
+- `data/real/dailyResult.json`：按日快照，字段含 realized（M4+M5.2）、unrealized（M3）、以及 M1–M13。
+- UI 与脚本口径通过 `normalizeMetrics` 统一，M6 恒等式：M6 = M4 + M3 + M5.2。


### PR DESCRIPTION
## Summary
- run smoke backtests on main branch with a new workflow
- add real backtest docs and data templates
- block legacy M5_1 and M5_2 metrics via ESLint

## Testing
- `npm run ci`
- `npm run backtest:smoke -w web`


------
https://chatgpt.com/codex/tasks/task_e_68b4f898e888832ead167b2b1455f9f7