### PR TITLE
feat: add real data verification

### DIFF
--- a/.github/workflows/verify-real.yml
+++ b/.github/workflows/verify-real.yml
@@ -1,0 +1,21 @@
+name: verify-real
+on:
+  workflow_dispatch:
+    inputs:
+      from: { description: "Start date YYYY-MM-DD", required: false }
+      to:   { description: "End date YYYY-MM-DD",   required: false }
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - run: npm ci
+      - run: npm run backtest -w web -- --from=${{ inputs.from }} --to=${{ inputs.to }}
+      - run: npm run verify:real -w web -- --from=${{ inputs.from }} --to=${{ inputs.to }}
+      - name: Upload verify report
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-report
+          path: data/real/verify-report.md

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,10 +11,12 @@
     "check-types": "tsc --noEmit",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "replay": "tsx scripts/replay.ts",
+    "backtest": "tsx ./scripts/replay.ts",
     "check:monitor": "MONITOR=1 npm run replay",
     "test": "jest",
     "check:types": "tsc --noEmit",
-    "backtest:smoke": "node ./scripts/replay.js --from=2025-08-01 --to=2025-08-01 || node ./scripts/replay.ts --from=2025-08-01 --to=2025-08-01"
+    "backtest:smoke": "node ./scripts/replay.js --from=2025-08-01 --to=2025-08-01 || node ./scripts/replay.ts --from=2025-08-01 --to=2025-08-01",
+    "verify:real": "tsx ./scripts/verify-real.ts"
   },
   "dependencies": {
     "@radix-ui/react-tabs": "^1.1.12",
@@ -45,6 +47,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.0.0",
     "tailwindcss-animate": "^1.0.7",
+    "ts-node": "^10.9.2",
     "typescript": "5.8.2"
   }
 }

--- a/apps/web/scripts/verify-real.ts
+++ b/apps/web/scripts/verify-real.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+
+import fs from "node:fs";
+import path from "node:path";
+import { runAll } from "@/app/lib/runAll";
+import { normalizeMetrics } from "@/app/lib/metrics";
+
+// 复用 replay 的读文件工具（若不存在则内联一个安全读取）
+function readTextIfExists(p: string): string | undefined {
+  try { return fs.readFileSync(p, "utf8"); } catch { return undefined; }
+}
+function parseCsv(text?: string): any[] {
+  if (!text) return [];
+  const lines = text.replace(/^\uFEFF/, "").split(/\r?\n/).filter(Boolean);
+  if (lines.length === 0) return [];
+  const headers = lines[0].split(",").map(h => h.trim());
+  return lines.slice(1).map(line => {
+    const cols = line.split(",").map(c => c.trim());
+    const obj: Record<string, string> = {};
+    headers.forEach((h, i) => obj[h] = cols[i]);
+    return obj;
+  });
+}
+
+// 加载真实数据（CSV/JSON 二选一）
+function loadRealTrades(): any[] {
+  const base = path.resolve(process.cwd(), "data/real");
+  const json = readTextIfExists(path.join(base, "trades.json"));
+  if (json) return JSON.parse(json);
+  const csv = parseCsv(readTextIfExists(path.join(base, "trades.csv")));
+  // 统一字段：date,time,symbol,side,qty,price
+  return csv.map(r => ({
+    date: r.date, time: r.time, symbol: r.symbol,
+    side: r.side, qty: Number(r.qty), price: Number(r.price)
+  }));
+}
+function loadRealPrices(): any[] {
+  const base = path.resolve(process.cwd(), "data/real");
+  const json = readTextIfExists(path.join(base, "prices.json"));
+  if (json) return JSON.parse(json);
+  const csv = parseCsv(readTextIfExists(path.join(base, "prices.csv")));
+  return csv.map(r => ({ date: r.date, symbol: r.symbol, close: Number(r.close) }));
+}
+
+type DailySnap = { date: string; realized: number; unrealized: number; M6?: number; [k:string]: any };
+function loadDailyResult(): DailySnap[] {
+  const base = path.resolve(process.cwd(), "data/real");
+  const text = readTextIfExists(path.join(base, "dailyResult.json"));
+  if (!text) return [];
+  try { return JSON.parse(text); } catch { return []; }
+}
+
+// 取区间
+function pickDates(snap: DailySnap[], from?: string, to?: string): string[] {
+  const dates = Array.from(new Set(snap.map(r => r.date))).sort();
+  const ok = dates.filter(d => (!from || d >= from) && (!to || d <= to));
+  return ok;
+}
+
+function round2(n: number) { return Math.round(n * 100) / 100; }
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const from = argv.find(a => a.startsWith("--from="))?.split("=")[1];
+  const to   = argv.find(a => a.startsWith("--to="))?.split("=")[1];
+
+  const trades = loadRealTrades();
+  const prices = loadRealPrices();
+  const snaps  = loadDailyResult();
+
+  if (trades.length === 0 && prices.length === 0 && snaps.length === 0) {
+    console.log("real-data-verify: 没有发现 data/real/*，跳过校验（视为通过）。");
+    process.exit(0);
+  }
+
+  if (snaps.length === 0) {
+    console.error("real-data-verify: 缺少 data/real/dailyResult.json，请先运行回放：npm run backtest -w web -- --from=YYYY-MM-DD --to=YYYY-MM-DD");
+    process.exit(2);
+  }
+
+  const dates = pickDates(snaps, from, to);
+  const mismatches: string[] = [];
+
+  for (const d of dates) {
+    // 过滤出当日数据
+    const dayTrades = trades.filter(t => t.date === d);
+    const dayPrices = prices.filter(p => p.date === d);
+    // 基于当日重算
+    const res = runAll({ trades: dayTrades, prices: dayPrices });
+    const m = normalizeMetrics(res);
+    const realize = round2(m.M4.total + m.M5.fifo);
+    const unrl   = round2(m.M3);
+    const m6     = round2(m.M6.total);
+
+    const snap = snaps.find(s => s.date === d) as DailySnap;
+    const sRealized   = round2(Number(snap?.realized ?? NaN));
+    const sUnrealized = round2(Number(snap?.unrealized ?? NaN));
+    const sM6         = round2(Number(snap?.M6 ?? snap?.total ?? NaN)); // 兼容字段
+
+    const okReal = realize === sRealized;
+    const okUnrl = unrl === sUnrealized;
+    const okM6   = m6 === sM6;
+
+    if (!(okReal && okUnrl && okM6)) {
+      mismatches.push(
+        `[${d}] realized: ${realize} != ${sRealized}; unrealized: ${unrl} != ${sUnrealized}; M6: ${m6} != ${sM6}`
+      );
+    }
+  }
+
+  // 写报告
+  const report = [
+    "# Real Data Verify Report",
+    "",
+    `区间: ${from ?? dates[0]} ~ ${to ?? dates[dates.length-1]}`,
+    `总天数: ${dates.length}`,
+    `不一致天数: ${mismatches.length}`,
+    "",
+    ...(mismatches.length ? ["## 差异明细", ...mismatches] : ["所有日期均一致。"])
+  ].join("\n");
+
+  const out = path.resolve(process.cwd(), "data/real/verify-report.md");
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  fs.writeFileSync(out, report, "utf8");
+
+  if (mismatches.length) {
+    console.error("real-data-verify: 存在不一致，详见 data/real/verify-report.md");
+    process.exit(1);
+  } else {
+    console.log("real-data-verify: 校验通过 ✔");
+  }
+}
+main().catch(e => { console.error(e); process.exit(2); });

--- a/docs/REAL_BACKTEST.md
+++ b/docs/REAL_BACKTEST.md
@@ -42,3 +42,8 @@ npm run backtest -w web -- --from=YYYY-MM-DD --to=YYYY-MM-DD
 ## 产出
 - `data/real/dailyResult.json`：按日快照，字段含 realized（M4+M5.2）、unrealized（M3）、以及 M1–M13。
 - UI 与脚本口径通过 `normalizeMetrics` 统一，M6 恒等式：M6 = M4 + M3 + M5.2。
+
+## 校验（重要）
+- 本地：`npm run verify:real -w web -- --from=YYYY-MM-DD --to=YYYY-MM-DD`
+- CI：在 GitHub Actions 里触发 **verify-real** 工作流，选填 from/to。
+- 通过标准：对每个交易日，realized == (M4.total + M5.fifo)，unrealized == M3，且 M6 等式成立。报告输出到 `data/real/verify-report.md`。

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.0.0",
         "tailwindcss-animate": "^1.0.7",
+        "ts-node": "^10.9.2",
         "typescript": "5.8.2"
       }
     },
@@ -120,6 +121,50 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "apps/web/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "apps/web/node_modules/typescript": {
@@ -658,6 +703,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.4",
@@ -3281,6 +3350,34 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -4111,6 +4208,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
@@ -4186,6 +4296,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4938,6 +5055,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5264,6 +5388,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/docs": {
@@ -10809,6 +10943,13 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmmirror.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -11183,6 +11324,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
## Summary
- add script to verify real trade metrics and report mismatches
- expose `verify:real` command and CI workflow
- document how to run real data verification
- add `backtest` script to web package for replaying data

## Testing
- `npm run backtest -w web -- --from=2025-08-01 --to=2025-08-01`
- `npm run verify:real -w web -- --from=2025-08-01 --to=2025-08-01`
- `npm test -w web`


------
https://chatgpt.com/codex/tasks/task_e_68b50344149c832eaa4aaa328056c281