### PR TITLE
chore: add nightly verify-real workflow and README badge

### DIFF
--- a/.github/workflows/verify-real.yml
+++ b/.github/workflows/verify-real.yml
@@ -1,21 +1,25 @@
 name: verify-real
+
 on:
-  workflow_dispatch:
-    inputs:
-      from: { description: "Start date YYYY-MM-DD", required: false }
-      to:   { description: "End date YYYY-MM-DD",   required: false }
+  workflow_dispatch: {}
+  schedule:
+    # 工作日美东收盘后跑：02:30 UTC ≈ 22:30 ET(夏令) / 21:30 ET(冬令)；按需再调
+    - cron: "30 2 * * 1-5"
+
 jobs:
   verify:
+    name: verify:real
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 22 }
+        with: { node-version: '22' }
       - run: npm ci
-      - run: npm run backtest -w web -- --from=${{ inputs.from }} --to=${{ inputs.to }}
-      - run: npm run verify:real -w web -- --from=${{ inputs.from }} --to=${{ inputs.to }}
+      - run: npm run backtest -w web -- --from=2025-08-01 --to=2025-08-01
+      - run: npm run verify:real -w web -- --from=2025-08-01 --to=2025-08-01
       - name: Upload verify report
         uses: actions/upload-artifact@v4
         with:
           name: verify-report
           path: data/real/verify-report.md
+

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -66,3 +66,15 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - 文档：./../../docs/REAL_BACKTEST.md
 - 快速命令：`npm run backtest:smoke -w web`（黄金用例）
 - 自定义区间：`npm run backtest -w web -- --from=YYYY-MM-DD --to=YYYY-MM-DD`
+
+## Real Data Verify
+
+[![Verify Real Data](https://github.com/qiqiMagicCity/Trading777/actions/workflows/verify-real.yml/badge.svg)](https://github.com/qiqiMagicCity/Trading777/actions/workflows/verify-real.yml)
+
+- 手动触发：在 GitHub Actions 里运行 **Verify Real**。
+- 本地运行：
+  ```bash
+  npm run backtest -w web -- --from=2025-08-01 --to=2025-08-01
+  npm run verify:real -w web -- --from=2025-08-01 --to=2025-08-01
+  ```
+- 校验项：聚合后的 M4/M5.2/M9 与 breakdown 汇总一致；前台 M5.1=1670、M5.2=1320 与黄金案例对齐。出现不一致会在 `data/real/verify-report.md` 给出差异列表。


### PR DESCRIPTION
## Summary
- schedule nightly verify-real job and fixed date range
- document Real Data Verify workflow with badge and run instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b517b9dac4832e8c77c69b78b66c52