### PR TITLE
Remove option trade toggle from add trade modal

### DIFF
--- a/apps/web/app/components/AddTradeModal.tsx
+++ b/apps/web/app/components/AddTradeModal.tsx
@@ -12,48 +12,17 @@ interface Props {
   trade?: Trade;
 }
 
-function buildOptionSymbol(root: string, dateStr: string, cp: string, strike: number): string {
-  if (!root || !dateStr || !cp || !strike) return '';
-
-  // Format: AAPL230915C00165000
-  const date = toNY(dateStr);
-  const yy = date.getFullYear().toString().slice(-2);
-  const mm = (date.getMonth() + 1).toString().padStart(2, '0');
-  const dd = date.getDate().toString().padStart(2, '0');
-  const strikeStr = (strike * 1000).toFixed(0).padStart(8, '0');
-
-  return `${root}${yy}${mm}${dd}${cp}${strikeStr}`;
-}
-
 export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
   const editing = !!trade;
   const [symbol, setSymbol] = useState('');
   const [side, setSide] = useState<'BUY' | 'SELL' | 'SHORT' | 'COVER'>('BUY');
   const [qty, setQty] = useState<number>(0);
   const [price, setPrice] = useState<number>(0);
-  const [isOption, setIsOption] = useState(false);
-
-  // Option fields
-  const [optRoot, setOptRoot] = useState('');
-  const [optExp, setOptExp] = useState('');
-  const [optType, setOptType] = useState<'C' | 'P'>('C');
-  const [optStrike, setOptStrike] = useState<number>(0);
 
   // Get current NY time for default
   const defaultDatetime = nowNY().toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM format
 
   const [datetime, setDatetime] = useState(defaultDatetime);
-
-  // Generate option symbol when fields change
-  const generatedOptionSymbol = isOption
-    ? buildOptionSymbol(optRoot, optExp, optType, optStrike)
-    : '';
-
-  useEffect(() => {
-    if (isOption && generatedOptionSymbol && symbol !== generatedOptionSymbol) {
-      setSymbol(generatedOptionSymbol);
-    }
-  }, [isOption, generatedOptionSymbol, symbol]);
 
   // ---------- 同步传入的 trade 数据 ----------
   useEffect(() => {
@@ -75,25 +44,6 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
         console.error('无法解析日期:', trade.date, e);
       }
 
-      // 根据 symbol 判断是否为期权（简单判断：长度 > 6 且包含C或P第6位）
-      const isOpt = trade.symbol.length > 6 && /[CP]\d{8}$/.test(trade.symbol);
-      setIsOption(isOpt);
-      if (isOpt) {
-        // 尝试解析期权 symbol，若失败则忽略
-        const root = trade.symbol.slice(0, trade.symbol.length - 15);
-        setOptRoot(root);
-        setOptType(trade.symbol.charAt(trade.symbol.length - 15) as 'C' | 'P');
-        const expStr = trade.symbol.slice(root.length, root.length + 6); // YYMMDD
-        if (expStr.length === 6) {
-          const yy = '20' + expStr.slice(0, 2);
-          const mm = expStr.slice(2, 4);
-          const dd = expStr.slice(4, 6);
-          setOptExp(`${yy}-${mm}-${dd}`);
-        }
-        const strikeStr = trade.symbol.slice(-8);
-        const strike = parseInt(strikeStr, 10) / 1000;
-        setOptStrike(strike);
-      }
     }
   }, [trade]);
 
@@ -131,14 +81,6 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
       <div className="modal-content">
         <h3>{editing ? '编辑交易' : '添加交易'}</h3>
         <form onSubmit={handleSubmit}>
-          <label>是否期权</label>
-          <input
-            type="checkbox"
-            checked={isOption}
-            onChange={e => setIsOption(e.target.checked)}
-            style={{ width: 'auto' }}
-          />
-
           <label>交易时间</label>
           <input
             type="datetime-local"
@@ -147,58 +89,12 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
             required
           />
 
-          {!isOption ? (
-            <div>
-              <label>股票代码</label>
-              <input
-                value={symbol}
-                onChange={e => setSymbol(e.target.value)}
-                required
-              />
-            </div>
-          ) : (
-            <div>
-              <label>正股</label>
-              <input
-                value={optRoot}
-                onChange={e => setOptRoot(e.target.value.trim().toUpperCase())}
-                placeholder="AAPL"
-                required
-              />
-
-              <label>到期日</label>
-              <input
-                type="date"
-                value={optExp}
-                onChange={e => setOptExp(e.target.value)}
-                required
-              />
-
-              <label>期权类型</label>
-              <select
-                value={optType}
-                onChange={e => setOptType(e.target.value as 'C' | 'P')}
-              >
-                <option value="C">Call</option>
-                <option value="P">Put</option>
-              </select>
-
-              <label>行权价</label>
-              <input
-                type="number"
-                step="0.01"
-                value={optStrike || ''}
-                onChange={e => setOptStrike(parseFloat(e.target.value) || 0)}
-                required
-              />
-
-              <label>生成代码</label>
-              <input
-                value={generatedOptionSymbol}
-                readOnly
-              />
-            </div>
-          )}
+          <label>股票代码</label>
+          <input
+            value={symbol}
+            onChange={e => setSymbol(e.target.value)}
+            required
+          />
 
           <label>交易方向</label>
           <select


### PR DESCRIPTION
## Summary
- remove the option trade toggle and associated inputs from the add trade modal so only stock trades can be created

## Testing
- npm run lint *(fails: existing lint warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4a038160832e94c9fbbb55196b71