### PR TITLE
Await trade refresh after manual add

### DIFF
--- a/apps/web/app/components/AddTradeModal.tsx
+++ b/apps/web/app/components/AddTradeModal.tsx
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
 
 interface Props {
   onClose: () => void;
-  onAdded: () => void;
+  onAdded: () => Promise<void> | void;
   trade?: Trade;
 }
 
@@ -71,8 +71,11 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
       logger.debug('[AddTradeModal] 新增交易:', baseTrade);
       await addTrade(baseTrade);
     }
-
-    onAdded();
+    try {
+      await onAdded();
+    } catch (err) {
+      logger.error('[AddTradeModal] 刷新交易数据失败', err);
+    }
     onClose();
   };
 

--- a/apps/web/components/AddTradeModal.tsx
+++ b/apps/web/components/AddTradeModal.tsx
@@ -8,7 +8,7 @@ type Side = 'BUY' | 'SELL' | 'SHORT' | 'COVER';
 
 interface Props {
   onClose: () => void;
-  onAdded: () => void;
+  onAdded: () => Promise<void> | void;
   trade?: EnrichedTrade;
 }
 
@@ -84,7 +84,11 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
         action
       });
     }
-    onAdded();
+    try {
+      await onAdded();
+    } catch (err) {
+      logger.error('[AddTradeModal] 刷新交易数据失败', err);
+    }
     onClose();
   };
 


### PR DESCRIPTION
## Summary
- allow the AddTrade modal to await asynchronous refresh callbacks before closing
- log an error when the post-submit refresh fails, preserving visibility into failed reloads
- mirror the same async handling in the legacy AddTrade modal component

## Testing
- npm run lint -w web *(fails: existing lint warnings in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4fa5eb70832eadcaa6527c1ec90a