### PR TITLE
Force uppercase ticker input in add trade modal

### DIFF
--- a/apps/web/app/components/AddTradeModal.tsx
+++ b/apps/web/app/components/AddTradeModal.tsx
@@ -28,7 +28,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
   useEffect(() => {
     if (trade) {
       logger.debug('[AddTradeModal] 编辑模式载入:', trade);
-      setSymbol(trade.symbol);
+      setSymbol(trade.symbol.toUpperCase());
       if (!trade.action) {
         console.warn('Editing trade has invalid action, defaulting to BUY.');
       }
@@ -95,7 +95,7 @@ export default function AddTradeModal({ onClose, onAdded, trade }: Props) {
           <label>股票代码</label>
           <input
             value={symbol}
-            onChange={e => setSymbol(e.target.value)}
+            onChange={e => setSymbol(e.target.value.toUpperCase())}
             required
           />
 


### PR DESCRIPTION
## Summary
- ensure existing trades load with uppercased symbols in the add trade modal
- automatically uppercase ticker input while typing when creating or editing a trade

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc52ee6a9c832e977b641f26a211fa