### PR TITLE
调整胜率模块显示格式

### DIFF
--- a/apps/web/app/modules/DashboardMetrics.tsx
+++ b/apps/web/app/modules/DashboardMetrics.tsx
@@ -133,10 +133,7 @@ export function DashboardMetrics({ enrichedTrades, positions }: Props) {
           <>
             <span className="green">W/{m10.win}</span>{" "}
             <span className="red">L/{m10.loss}</span>{" "}
-            <span>F/{m10.flat}</span>{" "}
-            <span className={m10.rate >= 0.5 ? "green" : "red"}>
-              {(m10.rate * 100).toFixed(1)}%
-            </span>
+            <span>{(m10.rate * 100).toFixed(1)}%</span>
           </>
         );
       } else {


### PR DESCRIPTION
## Summary
- 按照规范更新功能区1 M10 胜率模块的前端展示，移除无关的 F/ 统计并统一胜率字体颜色

## Testing
- npm run lint -- --filter=web *(fails: existing lint warnings in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cc592a21ec832e8f9e15764b344a02