### PR TITLE
在纽约收盘后用实时报价回填收盘价

### DIFF
--- a/apps/web/app/lib/services/dataService.ts
+++ b/apps/web/app/lib/services/dataService.ts
@@ -34,7 +34,7 @@ export interface CachedPrice {
   symbol: string;
   date: string;
   close: number;
-  source: "finnhub" | "alphavantage" | "import" | "tiingo";
+  source: "finnhub" | "alphavantage" | "import" | "tiingo" | "close_rt";
 }
 
 // Interface for metricsDaily records


### PR DESCRIPTION
## Summary
- 新增纽约时间收盘判定工具，允许在收盘后使用实时行情作为收盘价
- 当日收盘价缺失且已过收盘时，尝试使用 Finnhub/Tiingo 实时报价写入缓存与文件
- 扩展本地缓存价格来源类型以覆盖新的 close_rt 标记

## Testing
- npm run check-types -w web

------
https://chatgpt.com/codex/tasks/task_e_68ccb5f6db20832e90160fe2f5a27888