### PR TITLE
Fix runAll date-only trade classification

### DIFF
--- a/apps/web/app/lib/__tests__/runAll-date-only.test.ts
+++ b/apps/web/app/lib/__tests__/runAll-date-only.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "@jest/globals";
+import { runAll } from "@/app/lib/runAll";
+import { normalizeMetrics } from "@/app/lib/metrics";
+
+describe("runAll date-only trades", () => {
+  it("counts trades recorded with date-only strings as today's activity", async () => {
+    const evalISO = "2024-08-20";
+    const trades = [
+      { date: evalISO, side: "BUY" as const, symbol: "AAA", qty: 1, price: 10 },
+      { date: evalISO, side: "SELL" as const, symbol: "AAA", qty: 1, price: 11 },
+    ];
+
+    const res = await runAll(
+      evalISO,
+      [],
+      trades,
+      {},
+      { dailyResults: [] },
+      { evalDate: evalISO },
+    );
+
+    const metrics = normalizeMetrics(res);
+
+    expect(metrics.M5.behavior).toBeCloseTo(1, 6);
+    expect(metrics.M5.fifo).toBeCloseTo(1, 6);
+  });
+});

--- a/apps/web/app/lib/runAll.ts
+++ b/apps/web/app/lib/runAll.ts
@@ -64,7 +64,7 @@ export function getReplayDays(
     }
   }
   for (const t of trades) {
-    const d = nyDateStr(t.date);
+    const d = nyDateStrSafe(t.date);
     if (within(d)) set.add(d);
   }
   return Array.from(set).sort();
@@ -110,6 +110,15 @@ export function normalizeClosePriceMap(input: any): ClosePriceMap {
     }
   }
   return out;
+}
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function nyDateStrSafe(input: string): string {
+  if (DATE_ONLY_RE.test(input)) {
+    return nyDateStr(`${input}T12:00:00Z`);
+  }
+  return nyDateStr(input);
 }
 
 // --- M5/M4 计算核心工具 ---
@@ -368,7 +377,7 @@ function runAllCore(
   const sortedTrades = [...rawTrades].sort((a, b) => a.date.localeCompare(b.date));
   for (const t of sortedTrades) {
     const st = getSym(t.symbol);
-    const today = nyDateStr(t.date) === evalISO;
+    const today = nyDateStrSafe(t.date) === evalISO;
     if (t.side === 'BUY') {
       st.longLots.push({ qty: t.qty, cost: t.price, isToday: today, openPrice: t.price, time: t.date });
       if (today) st.behLong.push({ qty: t.qty, cost: t.price, isToday: true, openPrice: t.price, time: t.date });


### PR DESCRIPTION
## Summary
- adjust runAll to normalize date-only trade timestamps to a safe New York midday instant before comparing them with the evaluation date
- reuse the normalized date when gathering replay days so stored trades no longer fall back to the previous calendar day
- add a regression test confirming that date-only trades contribute to M5 behavior and FIFO metrics

## Testing
- npm test -- --runTestsByPath apps/web/app/lib/__tests__/runAll-date-only.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ccba11fc80832e9b62f7a3e561d487