### PR TITLE
fix: include trade fallback in M5 behavior

### DIFF
--- a/apps/web/app/lib/metrics.ts
+++ b/apps/web/app/lib/metrics.ts
@@ -950,7 +950,9 @@ export function normalizeMetrics(input:any): MetricsContract {
   const M3 = Number(input?.M3 ?? 0);
   const M4 = { total: pickTotal(input?.M4) };
   const M5 = {
-    behavior: Number(input?.M5?.behavior ?? input?.M5_1 ?? 0),
+    behavior: Number(
+      input?.M5?.behavior ?? input?.M5?.trade ?? input?.M5_1 ?? 0,
+    ),
     fifo:      Number(input?.M5?.fifo      ?? input?.M5_2 ?? 0),
   };
   const M6 = { total: pickTotal(input?.M6) };


### PR DESCRIPTION
## Summary
- include the trade-based M5 value in the behavior fallback chain during metrics normalization

## Testing
- npm test -- --runTestsByPath apps/web/app/lib/__tests__/metrics-*.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ccc59808f4832ea824948b3ab12a17