### PR TITLE
Fix M7 counts to only include evaluation-day trades

### DIFF
--- a/tests/reliability.multiday.spec.ts
+++ b/tests/reliability.multiday.spec.ts
@@ -34,8 +34,9 @@ describe('reliability multi-day baseline', () => {
     expect(res.M5_1).toBeCloseTo(1670, 2);
     expect(res.M5_2).toBeCloseTo(1320, 2);
     expect(res.M6).toBeCloseTo(8952.5, 2);
-    expect(res.M7).toEqual({ B: 8, S: 8, P: 5, C: 4, total: 25 });
+    expect(res.M7).toEqual({ B: 6, S: 8, P: 4, C: 4, total: 22 });
     expect(res.M8).toEqual({ B: 8, S: 8, P: 5, C: 4, total: 25 });
+    expect(res.M7).not.toEqual(res.M8);
     expect(res.M9).toBe(8450);
     expect(res.M10).toEqual({ W: 11, L: 2, winRatePct: 84.6 });
     expect(res.M11).toBeCloseTo(9552.5, 2);


### PR DESCRIPTION
## Summary
- ensure M7 counts only include trades executed on the evaluation day while keeping the wider safeTrades pool for other metrics
- improve debug logging to show both total and daily trade counts used in M7
- update the multiday reliability spec to expect the corrected M7 totals and to verify M7 differs from M8 when prior-day trades exist

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd8bd4cfb4832e9b231dc402b9a0a1