### PR TITLE
Fix New York trading day detection

### DIFF
--- a/apps/web/app/lib/__tests__/timezone.test.ts
+++ b/apps/web/app/lib/__tests__/timezone.test.ts
@@ -12,6 +12,18 @@ describe("getLatestTradingDayStr", () => {
       "2024-05-06",
     );
   });
+
+  it("keeps same trading day during late evening", () => {
+    expect(getLatestTradingDayStr(new Date("2024-05-17T20:57:00-04:00"))).toBe(
+      "2024-05-17",
+    );
+  });
+
+  it("carries Friday forward through the weekend", () => {
+    expect(getLatestTradingDayStr(new Date("2024-05-18T20:00:00-04:00"))).toBe(
+      "2024-05-17",
+    );
+  });
 });
 
 describe("DST transitions", () => {


### PR DESCRIPTION
## Summary
- reimplement the toNY helper with date-fns-tz conversions so New York time math is stable across client timezones
- keep prior trading day visible through late evenings and weekends by relying on the corrected helper
- cover the late-evening and weekend scenarios with new unit tests for getLatestTradingDayStr

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdfc691cdc832eb6b4709a80e86013